### PR TITLE
Improvements to the ready 'rdy' commandline utility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
             - ocl-icd-opencl-dev
             - libgtk2.0-dev
             - libwxgtk3.0-dev
+            - libboost-all-dev
   allow_failures:
     - os: osx
       before_install:
         - brew update
-        - brew install homebrew/science/vtk wxmac
-
+        - brew install homebrew/science/vtk wxmac boost
 
 branches:
   only:

--- a/BUILD.txt
+++ b/BUILD.txt
@@ -3,6 +3,7 @@ Dependencies:
 1) VTK (latest version, or at least 6.2): www.vtk.org
 2) wxWidgets (latest version, or at least 2.9.2): www.wxwidgets.org
 3) any OpenCL SDK.
+4) Boost > 1.50
 
 Ready uses CMake for pre-build setup. You might need to read some CMake
 documentation first to get the hang of it.
@@ -32,7 +33,12 @@ B) Build wxWidgets:
     nmake -f makefile.vc BUILD=release RUNTIME_LIBS=static UNICODE=1 DEBUG_INFO=0 DEBUG_FLAG=0 TARGET_CPU=AMD64
     nmake -f makefile.vc BUILD=debug RUNTIME_LIBS=static UNICODE=1 DEBUG_INFO=1 DEBUG_FLAG=1 TARGET_CPU=AMD64
 
-C) Build Ready:
+C) Build Boost:
+ - Follow instructions at http://boost.org and build with static runtime:
+    bootstrap
+    .\b2 link=static runtime-link=static
+
+D) Build Ready:
  - Run CMake and make a separate build folder for Ready.
  - Set wxWidgets_ROOT_DIR to your wxWidgets installation folder, if
    CMake didn't find the right version automatically.
@@ -44,6 +50,7 @@ C) Build Ready:
     C:/CUDA/lib/OpenCL.lib, or C:/CUDA/lib64/OpenCL.lib for 64-bit.
  - Set OPENCL_INCLUDE_DIRS to e.g.
     C:/CUDA/include
+ - Set Boost_INCLUDE_DIR to e.g. C:/boost_1_68_0
  - Generate, then open the resulting Ready.sln and build the Debug and
    Release targets. Set Ready as the "StartUp Project" to have it run
    by default.
@@ -76,7 +83,12 @@ B) Build wxWidgets:
    For 64-bit: (in a 64-bit Visual Studio command prompt)
     nmake -f makefile.vc BUILD=release RUNTIME_LIBS=static UNICODE=1 DEBUG_INFO=0 DEBUG_FLAG=0 TARGET_CPU=AMD64
 
-C) Build Ready:
+C) Build Boost:
+ - Follow instructions at http://boost.org and build with static runtime:
+    bootstrap
+    .\b2 link=static runtime-link=static
+
+D) Build Ready:
  - Open a 32/64-bit Visual Studio command prompt and type: cmake-gui
  - Create a target build folder, and select NMake Makefiles as the
    generator.
@@ -89,6 +101,7 @@ C) Build Ready:
     C:/CUDA/lib/OpenCL.lib, or C:/CUDA/lib64/OpenCL.lib for 64-bit.
  - Set OPENCL_INCLUDE_DIRS to e.g.
     C:/CUDA/include
+ - Set Boost_INCLUDE_DIR to e.g. C:/boost_1_68_0
  - Check the Advanced checkbox. Look for CMAKE_CXX_FLAGS_RELEASE and
    similar. Change all occurences of /MD to /MT, and /MDd to /MTd.
    This ensures that the C runtime is statically-linked.
@@ -104,10 +117,10 @@ C) Build Ready:
 A) Dependencies: 
 
 On Debian/Ubuntu:
-sudo apt-get install libgtk2.0-dev libxt-dev ocl-icd-opencl-dev libglu1-mesa-dev libvtk6-dev libwxgtk3.0-dev cmake-curses-gui build-essential git
+sudo apt-get install libgtk2.0-dev libxt-dev ocl-icd-opencl-dev libglu1-mesa-dev libvtk6-dev libwxgtk3.0-dev cmake-curses-gui build-essential git libboost-all-dev
 
 On Fedora:
-sudo dnf install vtk-devel wxGTK3-devel ocl-icd-devel opencl-headers gcc-c++
+sudo dnf install vtk-devel wxGTK3-devel ocl-icd-devel opencl-headers gcc-c++ boost-devel
 
 On other distros I'm not sure - please let us know!
 
@@ -147,7 +160,15 @@ cd build
 cmake .. -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=OFF
 make   # this also takes some time
 
-3. Build Ready:
+3. Install Boost
+
+Follow instructions at http://boost.org or elsewhere, depending on your preferred tools.
+
+E.g. with homebrew: 
+
+brew install boost
+
+4. Build Ready:
 
 cd ~   # or some other directory
 git clone https://github.com/GollyGang/ready.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,8 +484,8 @@ endif()
 add_executable( ${CMD_NAME} ${CMD_SOURCES} )
 target_link_libraries( ${CMD_NAME} readybase boost_program_options)
 
-# Link boost >1.65 (the improvements to the 'rdy' binary will not build without it).
-find_package( Boost 1.65 COMPONENTS program_options REQUIRED )
+# Link boost >1.50 (the improvements to the 'rdy' binary will not build without it).
+find_package( Boost 1.50 COMPONENTS program_options REQUIRED )
 target_link_libraries( ${CMD_NAME} Boost::program_options )
 
 # create GUI application

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,16 @@ if( APPLE )
   link_libraries( ${OPENCL_LIBRARIES} ) # on MacOSX we assume that OpenCL is available (might need to rethink for versions before 10.6)
 endif()
 
+#-------------------------------------------Boost-----------------------------------------------
+
+if(WIN32)
+  set(Boost_USE_STATIC_LIBS        ON)
+  set(Boost_USE_MULTITHREADED      ON)
+  set(Boost_USE_STATIC_RUNTIME     ON)
+endif()
+find_package( Boost 1.50 COMPONENTS program_options REQUIRED )
+include_directories( ${Boost_INCLUDE_DIRS} )
+
 #---------------copy installation files to build folder (helps with testing)--------------------
 
 foreach( file ${PATTERN_FILES} ${HELP_FILES} ${RESOURCES} ${OTHER_FILES} )
@@ -482,11 +492,7 @@ endif()
 
 # create command-line utility
 add_executable( ${CMD_NAME} ${CMD_SOURCES} )
-target_link_libraries( ${CMD_NAME} readybase boost_program_options)
-
-# Link boost >1.50 (the improvements to the 'rdy' binary will not build without it).
-find_package( Boost 1.50 COMPONENTS program_options REQUIRED )
-target_link_libraries( ${CMD_NAME} Boost::program_options )
+target_link_libraries( ${CMD_NAME} readybase ${Boost_LIBRARIES})
 
 # create GUI application
 add_executable( ${APP_NAME} ${GUI_EXECUTABLE} ${GUI_SOURCES} ${RESOURCES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,9 +413,9 @@ if( EXISTS "/etc/redhat-release" )
  # This *should* work everywhere but causes problems on Debian 8 and Travis-CI
  target_link_libraries( readybase ${VTK_LIBRARIES} )
 else()
- if( UNIX AND NOT APPLE )
-  set( EXTRA_VTK_LIBS vtkIOMPIImage vtkIOMPIParallel vtkRenderingFreeTypeFontConfig vtkRenderingMatplotlib )
- endif()
+ #if( UNIX AND NOT APPLE )
+ # set( EXTRA_VTK_LIBS vtkIOMPIImage vtkIOMPIParallel vtkRenderingFreeTypeFontConfig vtkRenderingMatplotlib )
+ #endif()
  if( ${VTK_MAJOR_VERSION} LESS 6 )
   # VTK 5.x
   target_link_libraries( readybase vtkCommon vtkGraphics vtkIO vtkRendering vtkHybrid )
@@ -454,7 +454,7 @@ else()
     vtkRenderingCore
     vtkRenderingAnnotation
     vtkRenderingFreeType
-    vtkRenderingOpenGL
+    vtkRenderingOpenGL2
     ${EXTRA_VTK_LIBS}
   )
  else()
@@ -479,9 +479,14 @@ else()
   )
  endif()
 endif()
+
 # create command-line utility
 add_executable( ${CMD_NAME} ${CMD_SOURCES} )
-target_link_libraries( ${CMD_NAME} readybase )
+target_link_libraries( ${CMD_NAME} readybase boost_program_options)
+
+# Link boost >1.65 (the improvements to the 'rdy' binary will not build without it).
+find_package( Boost 1.65 COMPONENTS program_options REQUIRED )
+target_link_libraries( ${CMD_NAME} Boost::program_options )
 
 # create GUI application
 add_executable( ${APP_NAME} ${GUI_EXECUTABLE} ${GUI_SOURCES} ${RESOURCES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,9 +423,9 @@ if( EXISTS "/etc/redhat-release" )
  # This *should* work everywhere but causes problems on Debian 8 and Travis-CI
  target_link_libraries( readybase ${VTK_LIBRARIES} )
 else()
- #if( UNIX AND NOT APPLE )
- # set( EXTRA_VTK_LIBS vtkIOMPIImage vtkIOMPIParallel vtkRenderingFreeTypeFontConfig vtkRenderingMatplotlib )
- #endif()
+ if( UNIX AND NOT APPLE )
+  set( EXTRA_VTK_LIBS vtkIOMPIImage vtkIOMPIParallel vtkRenderingFreeTypeFontConfig vtkRenderingMatplotlib )
+ endif()
  if( ${VTK_MAJOR_VERSION} LESS 6 )
   # VTK 5.x
   target_link_libraries( readybase vtkCommon vtkGraphics vtkIO vtkRendering vtkHybrid )
@@ -464,7 +464,7 @@ else()
     vtkRenderingCore
     vtkRenderingAnnotation
     vtkRenderingFreeType
-    vtkRenderingOpenGL2
+    vtkRenderingOpenGL
     ${EXTRA_VTK_LIBS}
   )
  else()
@@ -492,7 +492,7 @@ endif()
 
 # create command-line utility
 add_executable( ${CMD_NAME} ${CMD_SOURCES} )
-target_link_libraries( ${CMD_NAME} readybase ${Boost_LIBRARIES})
+target_link_libraries( ${CMD_NAME} readybase ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 
 # create GUI application
 add_executable( ${APP_NAME} ${GUI_EXECUTABLE} ${GUI_SOURCES} ${RESOURCES} )

--- a/Help/changes.html
+++ b/Help/changes.html
@@ -14,6 +14,7 @@
 <font size=+1><b>Changes in version 0.?? (released ???)</b></font>
 <ul>
 <li>Fix: Option to show multiple chemicals now works with 3D images and meshes too.
+<li>Improvement: The rdy command line utility accepts more arguments and can print VTI contents in text form for pipeing to other apps.
 </ul>
 
 <p>

--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -17,7 +17,11 @@
 
 // STL:
 #include <iostream>
+#include <execinfo.h>
 using namespace std;
+
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
 
 // stdlib:
 #include <stdlib.h>
@@ -27,56 +31,435 @@ using namespace std;
 #include <Properties.hpp>
 #include <OpenCL_utils.hpp>
 #include <AbstractRD.hpp>
+#include <OpenCLImageRD.hpp>
 
 // -------------------------------------------------------------------------------------------------------------
 
 void InitializeDefaultRenderSettings(Properties &render_settings);
 
+// Please keep the following in sync with the blurb below!:
 // -------------------------------------------------------------------------------------------------------------
 /*
-        A demonstration of using Ready as a processing back-end.
+        Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.
 
-        Currently it just loads a file, runs it for 1000 timesteps and then saves out the result. If we actually want
-        this utility to do something useful then we can add more command-line options.
+        It responds to various commandline arguments to load and print out parts of the system,
+		and can also still be used (like it used to work) to iterate the system to a specified number
+		of steps, and save it to a new vti file.
+		
+		The various print options can facilitate the import of ready simulations into other applications, (such 
+		as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,
+		(via -m), be ready for some large lumps of text on stdout when using that argument.
+		
+		Please let the Ready team (especially Dan Wills) know if there is something that you wish to print 
+		that currently isn't supported.
 */
 // -------------------------------------------------------------------------------------------------------------
+void printSeparator()
+{
+	cout << "================================\n";
+}
 
 int main(int argc,char *argv[])
 {
-    if(argc!=3)
-    {
-        cout << "A command-line utility to run Ready patterns without the GUI.\nUsage:   " << argv[0] << " <input_file> <output_file>\n";
-        return EXIT_FAILURE;
-    }
+	// Declare the (boost/program_options) supported options.
+	po::options_description desc("Options");
+	
+	std::string vti_in;
+	std::string vti_out;
+	
+	std::string blurb = "Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.\n"
+						"\n"
+        				"It responds to various commandline arguments to load and print out parts of the system,\n"
+						"and can also still be used (like it used to work) to iterate the system to a specified number\n"
+						"of steps, and save it to a new vti file.\n"
+						"\n"
+						"The various print options can facilitate the import of ready simulations into other applications, (such\n"
+						"as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,\n"
+						"(via -m), be ready for some large lumps of text on stdout when using that argument.\n"
+						"\n"
+						"Please let the Ready team (especially Dan Wills) know if there is something that you wish to print\n"
+						"that currently isn't supported.\n";
+	
+	desc.add_options()
+    	("help,h", "Print the help message")
+		// Went to 0 iterations by default. Need to provide option for flags
+    	("num-iterations,n", po::value<int>()->default_value(0), "Number of iterations to run before saving")
+    	("print-kernel,k", po::bool_switch()->default_value(false), "Print (full) OpenCL kernel source (when possible)")
+    	("print-formula,f", po::bool_switch()->default_value(false), "Print kernel formula (when possible)")
+    	("print-reagent-info,r", po::bool_switch()->default_value(false), "Print reagent info")
+		("print-parameter-info,p", po::bool_switch()->default_value(false), "Print parameter info")
+		("print-render-settings,s", po::bool_switch()->default_value(false), "Print render Settings")
+		("print-formula-description,d", po::bool_switch()->default_value(false), "Print formula Description")
+		("print-initial-state-images,m", po::bool_switch()->default_value(false), "Print initial state images (Warning: May be large!)")
+		("vti-in,i", po::value(&vti_in)->required(), "VTI file to load (required)")
+		("vti-out,o", po::value(&vti_out), "VTI file to save (optional)")
+		// TODO don't crash if incorrect, fail more gracefully!
+		("opencl-platform,l", po::value<int>(), "OpenCL platform number (Currently will crash if incorrect!)")
+		("opencl-device,g", po::value<int>(), "OpenCL device number (Currently will crash if incorrect!)")
+		("verbose,v", po::bool_switch()->default_value(false), "Verbose output.");
+  
+	po::variables_map vm;
+	try {
+		po::store( po::parse_command_line( argc, argv, desc ), vm );
+		po::notify( vm );
+	} catch ( const exception& e ) {
+		if ( vm.count("help") == 0 )
+		{
+			cout << "\nIt looks like one of the required arguments is missing or malformed:\n";
+			cout << e.what() << "\n\n";
+			cout << "Here's the help:\n";
+		} else {
+			cout << "\n" << blurb << "\n";
+			cout << "\n" << desc << "\n";
+    		return 1;
+		}
+	}
+	
+	int numiter = 1000;
+	bool print_kernel = false;
+	bool print_formula = false;
+	bool print_reagent_info = false;
+	bool print_parameter_info = false;
+	bool print_render_settings = false;
+	bool print_initial_state_images = false;
+	bool print_formula_description = false;
+	bool verbose = false;
+	int opencl_platform = 0;
+	int opencl_device = 0;
+	
+	if ( vm.count("help") )
+	{
+		cout << "\n" << blurb << "\n";
+    	cout << "\n" << desc << "\n";
+    	return 1;
+	}
 
+	if ( vm.count("verbose") )
+	{
+		verbose = vm["verbose"].as<bool>();
+		if (verbose)
+		{
+	    	cout << "Verbose was enabled.\n";
+		}
+	}
+	
+	if ( vm.count("num-iterations") )
+	{
+		numiter = vm["num-iterations"].as<int>();
+		if (verbose) 
+		{
+	    	cout << "Num Iterations was set to: " << vm["num-iterations"].as<int>() << ".\n";
+		}
+	} else {
+		if (verbose) 
+		{
+    		cout << "Num Iterations was not set (default is 1000).\n";
+		}
+	}
+	
+	if ( vm.count("print-kernel") )
+	{
+		print_kernel = vm["print-kernel"].as<bool>();
+	}
+	
+	if ( vm.count("print-formula") )
+	{
+		print_formula = vm["print-formula"].as<bool>();
+	}
+	
+	if ( vm.count("print-reagent-info") )
+	{
+		print_reagent_info = vm["print-reagent-info"].as<bool>();
+	}
+	
+	if ( vm.count("print-parameter-info") )
+	{
+		print_parameter_info = vm["print-parameter-info"].as<bool>();
+	}
+	
+	if ( vm.count("print-render-settings") )
+	{
+		print_render_settings = vm["print-render-settings"].as<bool>();
+	}
+	
+	if ( vm.count("print-formula-description") )
+	{
+		print_formula_description = vm["print-formula-description"].as<bool>();
+	}
+	
+	if ( vm.count("print-initial-state-images") )
+	{
+		print_initial_state_images = vm["print-initial-state-images"].as<bool>();
+	}
+	
+	if ( vm.count("vti-in") )
+	{
+		if (verbose) 
+		{
+			cout << "VTI-in flag detected!\n";
+		}
+	}
+	
+	if ( vm.count("vti-out") )
+	{
+		if (verbose) 
+		{
+			cout << "VTI-out flag detected!\n";
+		}
+	}
+	
+    if ( vm.count("opencl-platform") )
+	{
+		opencl_platform = vm["opencl-platform"].as<int>();
+		if (verbose) 
+		{
+	    	cout << "OpenCl platform was set to: " << opencl_platform << ".\n";
+		}
+	}
+	
+	if ( vm.count("opencl-device") )
+	{
+		opencl_device = vm["opencl-device"].as<int>();
+		if (verbose) 
+		{
+	    	cout << "OpenCl device was set to: " << opencl_device << ".\n";
+		}
+	}
+	
     bool is_opencl_available = OpenCL_utils::IsOpenCLAvailable();
-    if(is_opencl_available)
-        cout << "OpenCL found.\n";
-    else
-        cout << "OpenCL not found.\n";
-    int opencl_platform = 0; // TODO: command-line option
-    int opencl_device = 0; // TODO: command-line option
-
+	
+    if( is_opencl_available )
+	{
+		if (verbose)
+		{
+	        cout << "OpenCL found.\n";
+		}
+	} else {
+		// Still print (despite not verbose) since it's a warning:
+		cout << "Warning: OpenCL not found! (This may not bode well for what's about to happen..).\n";
+	}
+	
     Properties render_settings("render_settings");
     InitializeDefaultRenderSettings(render_settings);
 
     AbstractRD *system;
-    try
+    try 
     {
-        // read the file
-        cout << "Loading file...\n";
+        // Read the file
+		if (verbose)
+		{
+	        cout << "Loading VTI file: " << vti_in << "...\n";
+		}
         bool warn_to_update;
-        system = SystemFactory::CreateFromFile(argv[1],is_opencl_available,opencl_platform,opencl_device,render_settings,warn_to_update);
-        if(warn_to_update)
+		try {
+			system = SystemFactory::CreateFromFile( vti_in.c_str(), is_opencl_available, opencl_platform, 
+			                                        opencl_device, render_settings, warn_to_update );
+			if (verbose)
+			{
+				cout << "Loaded VTI: " << vti_in.c_str() << "\n";
+			}
+			
+			system->Update( 0 );
+			if (verbose)
+			{
+				cout << "System updated to zeroth step..\n";
+			}
+							
+			if ( print_reagent_info ) 
+			{
+				int num_chemicals = system->GetNumberOfChemicals();
+				int xres = system->GetX();
+				int yres = system->GetY();
+				int zres = system->GetZ();
+				int arena_dimensionality = system->GetArenaDimensionality();
+				cout << "\n";
+				cout << "Reagent info:\n";
+				printSeparator();
+				//cout << "================================\n";
+				cout << "num_chemicals=" << num_chemicals << "\n";
+				cout << "arena_dimensionality=" << arena_dimensionality << "\n";
+				cout << "xres=" << xres << "\n";
+				cout << "yres=" << yres << "\n";
+				cout << "zres=" << zres << "\n";
+				cout << "================================\n";
+			}
+
+			if ( print_kernel ) 
+			{
+				cout << "\n";
+				cout << "Kernel source:\n";
+				cout << "================================\n";
+				cout << system->GetKernel();
+				cout << "================================\n";
+			}
+			
+			if ( print_formula ) 
+			{
+				cout << "\n";
+				cout << "Kernel formula:\n";
+				cout << "================================\n";
+				// Maybe work out how to strip leading whitespace from lines in this:
+				cout << system->GetFormula();
+				cout << "================================\n";
+			}
+			
+			if ( print_parameter_info )
+			{
+				int nparams = system->GetNumberOfParameters();
+				
+				cout << "\n";
+				cout << "Parameter info:\n";
+				cout << "================================\n";
+				for ( int ix=0; ix < nparams; ix++ )
+				{
+					std::string parm_name = system->GetParameterName( ix );
+					float parm_value = system->GetParameterValue( ix );
+					cout << parm_name << "=" << parm_value << "\n";
+				}
+				cout << "================================\n";
+			}
+			
+			if ( print_render_settings )
+			{
+				cout << "\n";
+				cout << "Render settings:\n";
+				cout << "================================\n";
+				
+				// A good example cast, left as a relic:
+				//AbstractRD* rdPlayer = dynamic_cast<AbstractRD*>(system);
+				//FormulaOpenCLImageRD* rdPlayer = dynamic_cast<FormulaOpenCLImageRD*>(system);				
+				//Properties *render_settings = rdPlayer->render_settings;
+				
+				int num_properties = render_settings.GetNumberOfProperties();
+				cout << "Number of properties is: " << num_properties << "\n";
+				for (int i=0;i<num_properties;i++)
+				{
+					Property this_property = render_settings.GetProperty( i );
+					
+					std::string property_name = this_property.GetName();
+					std::string property_type = this_property.GetType();
+					
+					cout << "    name: " << property_name << ", type: " << property_type << ", value:";
+					if (property_type == "int")
+					{
+						int property_value = this_property.GetInt();
+						cout << " " << property_value << "\n";
+					} else if (property_type == "bool") {
+						bool property_value = this_property.GetBool();
+						cout << " " << property_value << "\n";
+					} else if (property_type == "float") {
+						float property_value = this_property.GetFloat();
+						cout << " " << property_value << "\n";
+					} else if (property_type == "color") {
+						float property_value_r, property_value_g, property_value_b;
+						this_property.GetColor( property_value_r, property_value_g, property_value_b);
+						cout << " (" << property_value_r << "," << property_value_g << "," << property_value_b << ")\n";
+					} else if (property_type == "chemical") {
+						std::string property_value = this_property.GetChemical();
+						cout << " " << property_value << "\n";
+					} else if (property_type == "axis") {
+						std::string property_value = this_property.GetAxis();
+						cout << " " << property_value << "\n";
+					}
+				}
+				cout << "================================\n";
+			}
+			
+			if ( print_formula_description )
+			{
+				cout << "\n";
+				cout << "Formula description:\n";
+				cout << "================================\n";
+				cout << system->GetDescription();
+				cout << "================================\n";
+			}
+			
+			if ( print_initial_state_images )
+			{
+				int num_chemicals = system->GetNumberOfChemicals();
+				cout << "\n";
+				cout << "Parameter initial-state images:\n";
+				cout << "================================\n";
+				// I'm just going to gloss over numberOfScalarComponents for the moment! (just hope it's always 1 or above!)
+				// so given that, in theory num_chemicals and nc should be equal!
+				
+				// Update to get everything initialised (and copy in the initial states)..
+				system->Update(0);
+				
+				for ( int ix=0; ix < num_chemicals; ix++ )
+				{
+					cout << "\n";
+					cout << "nchem: " << ix << "\n";
+					OpenCLImageRD *isystem = dynamic_cast< OpenCLImageRD* >(system);
+					
+					cout << "xres=" << system->GetX() << "\n";
+					cout << "yres=" << system->GetY() << "\n";
+					cout << "zres=" << system->GetZ() << "\n";
+					
+					// not in bytes!
+					unsigned long reagent_block_size = system->GetX() * system->GetY() * system->GetZ();
+					
+					cout << "Reagent block size is: " << reagent_block_size << "\n";
+					float *rd_data = new float[reagent_block_size];
+					
+					isystem->GetFromOpenCLBuffers( rd_data, ix );
+					
+					cout << "\nRD data for reagent " << ix << ": [ ";
+					for (unsigned long rix=0; rix<reagent_block_size; rix++)
+					{
+						cout << rd_data[rix];
+						if ( rix < reagent_block_size-1 )
+						{
+							cout << ",";
+						}
+					}
+					cout << " ]\n";
+					delete rd_data;
+				}
+				cout << "================================\n";
+			}
+		} catch(const exception& e) {
+			cout << "Error creating system!:\n" << e.what() << "\n"; 
+
+			void* callstack[128];
+			int i, frames = backtrace( callstack, 128 );
+			char** strs = backtrace_symbols( callstack, frames );
+			for (i = 0; i < frames; ++i) 
+			{
+				printf( "%s\n", strs[i] );
+			}
+			free(strs);
+			
+			cout << "Ignoring exception.\n";
+		}
+		
+        if( warn_to_update )
             cout << "This pattern was created with a newer version of Ready. You should update your copy.\n";
+		
+		if ( numiter > 0 )
+		{
+        	cout << "Run the simulation for " << numiter << " steps...\n";
+        	system->Update( numiter );
 
-        // do something with the file
-        cout << "Running the simulation for 1000 steps...\n";
-        system->Update(1000); // TODO: command-line option
-
-        // save something out
-        cout << "Saving file...\n";
-        system->SaveFile(argv[2],render_settings,false);
+			if ( vm.count("vti-out") )
+			{
+	        	// save something out
+    	    	cout << "Saving file as " << vti_out << " ...\n";
+				try {
+		        	system->SaveFile( vti_out.c_str(), render_settings, false );
+				} catch(const exception& e) { //doesn't catch segfaults! :/
+					cout << "Something went wrong when saving file to: " << vti_out.c_str() << "\n";
+					cout << e.what() << "\n";
+				}
+			} else {
+				cout << "Output file not specified, not saving anything.\n";
+			}
+		} else { 
+			if (verbose)
+			{
+				cout << "Zero iterations, simulation skipped.\n";
+			}
+		}
     }
     catch(const exception& e)
     {
@@ -93,28 +476,8 @@ int main(int argc,char *argv[])
 void InitializeDefaultRenderSettings(Properties &render_settings)
 {
     // TODO: code duplication here from frame.cpp, not sure how best to merge
-    render_settings.DeleteAllProperties();
-    render_settings.AddProperty(Property("surface_color","color",1.0f,1.0f,1.0f)); // RGB [0,1]
-    render_settings.AddProperty(Property("color_low","color",0.0f,0.0f,1.0f));
-    render_settings.AddProperty(Property("color_high","color",1.0f,0.0f,0.0f));
-    render_settings.AddProperty(Property("show_color_scale",true));
-    render_settings.AddProperty(Property("show_multiple_chemicals",true));
-    render_settings.AddProperty(Property("active_chemical","chemical","a"));
-    render_settings.AddProperty(Property("low",0.0f));
-    render_settings.AddProperty(Property("high",1.0f));
-    render_settings.AddProperty(Property("vertical_scale_1D",30.0f));
-    render_settings.AddProperty(Property("vertical_scale_2D",15.0f));
-    render_settings.AddProperty(Property("contour_level",0.25f));
-    render_settings.AddProperty(Property("use_wireframe",false));
-    render_settings.AddProperty(Property("show_cell_edges",false));
-    render_settings.AddProperty(Property("show_bounding_box",true));
-    render_settings.AddProperty(Property("slice_3D",true));
-    render_settings.AddProperty(Property("slice_3D_axis","axis","z"));
-    render_settings.AddProperty(Property("slice_3D_position",0.5f)); // [0,1]
-    render_settings.AddProperty(Property("show_displacement_mapped_surface",true));
-    render_settings.AddProperty(Property("color_displacement_mapped_surface",true));
-    render_settings.AddProperty(Property("use_image_interpolation",true));
-    render_settings.AddProperty(Property("timesteps_per_render",100));
+	// .. fixed!
+	render_settings.SetDefaultRenderSettings();
 }
 
 // -------------------------------------------------------------------------------------------------------------

--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -17,9 +17,9 @@
 
 // STL:
 #include <iostream>
-#include <execinfo.h>
 using namespace std;
 
+// Boost:
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
@@ -43,423 +43,425 @@ void InitializeDefaultRenderSettings(Properties &render_settings);
         Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.
 
         It responds to various commandline arguments to load and print out parts of the system,
-		and can also still be used (like it used to work) to iterate the system to a specified number
-		of steps, and save it to a new vti file.
-		
-		The various print options can facilitate the import of ready simulations into other applications, (such 
-		as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,
-		(via -m), be ready for some large lumps of text on stdout when using that argument.
-		
-		Please let the Ready team (especially Dan Wills) know if there is something that you wish to print 
-		that currently isn't supported.
+        and can also still be used (like it used to work) to iterate the system to a specified number
+        of steps, and save it to a new vti file.
+
+        The various print options can facilitate the import of ready simulations into other applications, (such
+        as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,
+        (via -m), be ready for some large lumps of text on stdout when using that argument.
+
+        Please let the Ready team (especially Dan Wills) know if there is something that you wish to print
+        that currently isn't supported.
 */
 // -------------------------------------------------------------------------------------------------------------
 void printSeparator()
 {
-	cout << "================================\n";
+    cout << "================================\n";
 }
 
 int main(int argc,char *argv[])
 {
-	// Declare the (boost/program_options) supported options.
-	po::options_description desc("Options");
-	
-	std::string vti_in;
-	std::string vti_out;
-	
-	std::string blurb = "Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.\n"
-						"\n"
-        				"It responds to various commandline arguments to load and print out parts of the system,\n"
-						"and can also still be used (like it used to work) to iterate the system to a specified number\n"
-						"of steps, and save it to a new vti file.\n"
-						"\n"
-						"The various print options can facilitate the import of ready simulations into other applications, (such\n"
-						"as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,\n"
-						"(via -m), be ready for some large lumps of text on stdout when using that argument.\n"
-						"\n"
-						"Please let the Ready team (especially Dan Wills) know if there is something that you wish to print\n"
-						"that currently isn't supported.\n";
-	
-	desc.add_options()
-    	("help,h", "Print the help message")
-		// Went to 0 iterations by default. Need to provide option for flags
-    	("num-iterations,n", po::value<int>()->default_value(0), "Number of iterations to run before saving")
-    	("print-kernel,k", po::bool_switch()->default_value(false), "Print (full) OpenCL kernel source (when possible)")
-    	("print-formula,f", po::bool_switch()->default_value(false), "Print kernel formula (when possible)")
-    	("print-reagent-info,r", po::bool_switch()->default_value(false), "Print reagent info")
-		("print-parameter-info,p", po::bool_switch()->default_value(false), "Print parameter info")
-		("print-render-settings,s", po::bool_switch()->default_value(false), "Print render Settings")
-		("print-formula-description,d", po::bool_switch()->default_value(false), "Print formula Description")
-		("print-initial-state-images,m", po::bool_switch()->default_value(false), "Print initial state images (Warning: May be large!)")
-		("vti-in,i", po::value(&vti_in)->required(), "VTI file to load (required)")
-		("vti-out,o", po::value(&vti_out), "VTI file to save (optional)")
-		// TODO don't crash if incorrect, fail more gracefully!
-		("opencl-platform,l", po::value<int>(), "OpenCL platform number (Currently will crash if incorrect!)")
-		("opencl-device,g", po::value<int>(), "OpenCL device number (Currently will crash if incorrect!)")
-		("verbose,v", po::bool_switch()->default_value(false), "Verbose output.");
-  
-	po::variables_map vm;
-	try {
-		po::store( po::parse_command_line( argc, argv, desc ), vm );
-		po::notify( vm );
-	} catch ( const exception& e ) {
-		if ( vm.count("help") == 0 )
-		{
-			cout << "\nIt looks like one of the required arguments is missing or malformed:\n";
-			cout << e.what() << "\n\n";
-			cout << "Here's the help:\n";
-		} else {
-			cout << "\n" << blurb << "\n";
-			cout << "\n" << desc << "\n";
-    		return 1;
-		}
-	}
-	
-	int numiter = 1000;
-	bool print_kernel = false;
-	bool print_formula = false;
-	bool print_reagent_info = false;
-	bool print_parameter_info = false;
-	bool print_render_settings = false;
-	bool print_initial_state_images = false;
-	bool print_formula_description = false;
-	bool verbose = false;
-	int opencl_platform = 0;
-	int opencl_device = 0;
-	
-	if ( vm.count("help") )
-	{
-		cout << "\n" << blurb << "\n";
-    	cout << "\n" << desc << "\n";
-    	return 1;
-	}
+    // Declare the (boost/program_options) supported options.
+    po::options_description desc("Options");
 
-	if ( vm.count("verbose") )
-	{
-		verbose = vm["verbose"].as<bool>();
-		if (verbose)
-		{
-	    	cout << "Verbose was enabled.\n";
-		}
-	}
-	
-	if ( vm.count("num-iterations") )
-	{
-		numiter = vm["num-iterations"].as<int>();
-		if (verbose) 
-		{
-	    	cout << "Num Iterations was set to: " << vm["num-iterations"].as<int>() << ".\n";
-		}
-	} else {
-		if (verbose) 
-		{
-    		cout << "Num Iterations was not set (default is 1000).\n";
-		}
-	}
-	
-	if ( vm.count("print-kernel") )
-	{
-		print_kernel = vm["print-kernel"].as<bool>();
-	}
-	
-	if ( vm.count("print-formula") )
-	{
-		print_formula = vm["print-formula"].as<bool>();
-	}
-	
-	if ( vm.count("print-reagent-info") )
-	{
-		print_reagent_info = vm["print-reagent-info"].as<bool>();
-	}
-	
-	if ( vm.count("print-parameter-info") )
-	{
-		print_parameter_info = vm["print-parameter-info"].as<bool>();
-	}
-	
-	if ( vm.count("print-render-settings") )
-	{
-		print_render_settings = vm["print-render-settings"].as<bool>();
-	}
-	
-	if ( vm.count("print-formula-description") )
-	{
-		print_formula_description = vm["print-formula-description"].as<bool>();
-	}
-	
-	if ( vm.count("print-initial-state-images") )
-	{
-		print_initial_state_images = vm["print-initial-state-images"].as<bool>();
-	}
-	
-	if ( vm.count("vti-in") )
-	{
-		if (verbose) 
-		{
-			cout << "VTI-in flag detected!\n";
-		}
-	}
-	
-	if ( vm.count("vti-out") )
-	{
-		if (verbose) 
-		{
-			cout << "VTI-out flag detected!\n";
-		}
-	}
-	
+    std::string vti_in;
+    std::string vti_out;
+
+    std::string blurb = "Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.\n"
+                        "\n"
+                        "It responds to various commandline arguments to load and print out parts of the system,\n"
+                        "and can also still be used (like it used to work) to iterate the system to a specified number\n"
+                        "of steps, and save it to a new vti file.\n"
+                        "\n"
+                        "The various print options can facilitate the import of ready simulations into other applications, (such\n"
+                        "as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,\n"
+                        "(via -m), be ready for some large lumps of text on stdout when using that argument.\n"
+                        "\n"
+                        "Please let the Ready team (especially Dan Wills) know if there is something that you wish to print\n"
+                        "that currently isn't supported.\n";
+
+    desc.add_options()
+        ("help,h", "Print the help message")
+        // Went to 0 iterations by default. Need to provide option for flags
+        ("num-iterations,n", po::value<int>()->default_value(0), "Number of iterations to run before saving")
+        ("print-kernel,k", po::bool_switch()->default_value(false), "Print (full) OpenCL kernel source (when possible)")
+        ("print-formula,f", po::bool_switch()->default_value(false), "Print kernel formula (when possible)")
+        ("print-reagent-info,r", po::bool_switch()->default_value(false), "Print reagent info")
+        ("print-parameter-info,p", po::bool_switch()->default_value(false), "Print parameter info")
+        ("print-render-settings,s", po::bool_switch()->default_value(false), "Print render Settings")
+        ("print-formula-description,d", po::bool_switch()->default_value(false), "Print formula Description")
+        ("print-initial-state-images,m", po::bool_switch()->default_value(false), "Print initial state images (Warning: May be large!)")
+        ("vti-in,i", po::value(&vti_in)->required(), "VTI file to load (required)")
+        ("vti-out,o", po::value(&vti_out), "VTI file to save (optional)")
+        // TODO don't crash if incorrect, fail more gracefully!
+        ("opencl-platform,l", po::value<int>(), "OpenCL platform number (Currently will crash if incorrect!)")
+        ("opencl-device,g", po::value<int>(), "OpenCL device number (Currently will crash if incorrect!)")
+        ("verbose,v", po::bool_switch()->default_value(false), "Verbose output.");
+
+    po::variables_map vm;
+    try {
+        po::store( po::parse_command_line( argc, argv, desc ), vm );
+        po::notify( vm );
+    } catch ( const exception& e ) {
+        if ( vm.count("help") == 0 )
+        {
+            cout << "\nIt looks like one of the required arguments is missing or malformed:\n";
+            cout << e.what() << "\n\n";
+            cout << "Here's the help:\n";
+        } else {
+            cout << "\n" << blurb << "\n";
+            cout << "\n" << desc << "\n";
+            return 1;
+        }
+    }
+
+    int numiter = 1000;
+    bool print_kernel = false;
+    bool print_formula = false;
+    bool print_reagent_info = false;
+    bool print_parameter_info = false;
+    bool print_render_settings = false;
+    bool print_initial_state_images = false;
+    bool print_formula_description = false;
+    bool verbose = false;
+    int opencl_platform = 0;
+    int opencl_device = 0;
+
+    if ( vm.count("help") )
+    {
+        cout << "\n" << blurb << "\n";
+        cout << "\n" << desc << "\n";
+        return 1;
+    }
+
+    if ( vm.count("verbose") )
+    {
+        verbose = vm["verbose"].as<bool>();
+        if (verbose)
+        {
+            cout << "Verbose was enabled.\n";
+        }
+    }
+
+    if ( vm.count("num-iterations") )
+    {
+        numiter = vm["num-iterations"].as<int>();
+        if (verbose)
+        {
+            cout << "Num Iterations was set to: " << vm["num-iterations"].as<int>() << ".\n";
+        }
+    } else {
+        if (verbose)
+        {
+            cout << "Num Iterations was not set (default is 1000).\n";
+        }
+    }
+
+    if ( vm.count("print-kernel") )
+    {
+        print_kernel = vm["print-kernel"].as<bool>();
+    }
+
+    if ( vm.count("print-formula") )
+    {
+        print_formula = vm["print-formula"].as<bool>();
+    }
+
+    if ( vm.count("print-reagent-info") )
+    {
+        print_reagent_info = vm["print-reagent-info"].as<bool>();
+    }
+
+    if ( vm.count("print-parameter-info") )
+    {
+        print_parameter_info = vm["print-parameter-info"].as<bool>();
+    }
+
+    if ( vm.count("print-render-settings") )
+    {
+        print_render_settings = vm["print-render-settings"].as<bool>();
+    }
+
+    if ( vm.count("print-formula-description") )
+    {
+        print_formula_description = vm["print-formula-description"].as<bool>();
+    }
+
+    if ( vm.count("print-initial-state-images") )
+    {
+        print_initial_state_images = vm["print-initial-state-images"].as<bool>();
+    }
+
+    if ( vm.count("vti-in") )
+    {
+        if (verbose)
+        {
+            cout << "VTI-in flag detected!\n";
+        }
+    }
+
+    if ( vm.count("vti-out") )
+    {
+        if (verbose)
+        {
+            cout << "VTI-out flag detected!\n";
+        }
+    }
+
     if ( vm.count("opencl-platform") )
-	{
-		opencl_platform = vm["opencl-platform"].as<int>();
-		if (verbose) 
-		{
-	    	cout << "OpenCl platform was set to: " << opencl_platform << ".\n";
-		}
-	}
-	
-	if ( vm.count("opencl-device") )
-	{
-		opencl_device = vm["opencl-device"].as<int>();
-		if (verbose) 
-		{
-	    	cout << "OpenCl device was set to: " << opencl_device << ".\n";
-		}
-	}
-	
+    {
+        opencl_platform = vm["opencl-platform"].as<int>();
+        if (verbose)
+        {
+            cout << "OpenCl platform was set to: " << opencl_platform << ".\n";
+        }
+    }
+
+    if ( vm.count("opencl-device") )
+    {
+        opencl_device = vm["opencl-device"].as<int>();
+        if (verbose)
+        {
+            cout << "OpenCl device was set to: " << opencl_device << ".\n";
+        }
+    }
+
     bool is_opencl_available = OpenCL_utils::IsOpenCLAvailable();
-	
+
     if( is_opencl_available )
-	{
-		if (verbose)
-		{
-	        cout << "OpenCL found.\n";
-		}
-	} else {
-		// Still print (despite not verbose) since it's a warning:
-		cout << "Warning: OpenCL not found! (This may not bode well for what's about to happen..).\n";
-	}
-	
+    {
+        if (verbose)
+        {
+            cout << "OpenCL found.\n";
+        }
+    } else {
+        // Still print (despite not verbose) since it's a warning:
+        cout << "Warning: OpenCL not found! (This may not bode well for what's about to happen..).\n";
+    }
+
     Properties render_settings("render_settings");
     InitializeDefaultRenderSettings(render_settings);
 
     AbstractRD *system;
-    try 
+    try
     {
         // Read the file
-		if (verbose)
-		{
-	        cout << "Loading VTI file: " << vti_in << "...\n";
-		}
+        if (verbose)
+        {
+            cout << "Loading VTI file: " << vti_in << "...\n";
+        }
         bool warn_to_update;
-		try {
-			system = SystemFactory::CreateFromFile( vti_in.c_str(), is_opencl_available, opencl_platform, 
-			                                        opencl_device, render_settings, warn_to_update );
-			if (verbose)
-			{
-				cout << "Loaded VTI: " << vti_in.c_str() << "\n";
-			}
-			
-			system->Update( 0 );
-			if (verbose)
-			{
-				cout << "System updated to zeroth step..\n";
-			}
-							
-			if ( print_reagent_info ) 
-			{
-				int num_chemicals = system->GetNumberOfChemicals();
-				int xres = system->GetX();
-				int yres = system->GetY();
-				int zres = system->GetZ();
-				int arena_dimensionality = system->GetArenaDimensionality();
-				cout << "\n";
-				cout << "Reagent info:\n";
-				printSeparator();
-				//cout << "================================\n";
-				cout << "num_chemicals=" << num_chemicals << "\n";
-				cout << "arena_dimensionality=" << arena_dimensionality << "\n";
-				cout << "xres=" << xres << "\n";
-				cout << "yres=" << yres << "\n";
-				cout << "zres=" << zres << "\n";
-				cout << "================================\n";
-			}
+        try {
+            system = SystemFactory::CreateFromFile( vti_in.c_str(), is_opencl_available, opencl_platform,
+                                                    opencl_device, render_settings, warn_to_update );
+            if (verbose)
+            {
+                cout << "Loaded VTI: " << vti_in.c_str() << "\n";
+            }
 
-			if ( print_kernel ) 
-			{
-				cout << "\n";
-				cout << "Kernel source:\n";
-				cout << "================================\n";
-				cout << system->GetKernel();
-				cout << "================================\n";
-			}
-			
-			if ( print_formula ) 
-			{
-				cout << "\n";
-				cout << "Kernel formula:\n";
-				cout << "================================\n";
-				// Maybe work out how to strip leading whitespace from lines in this:
-				cout << system->GetFormula();
-				cout << "================================\n";
-			}
-			
-			if ( print_parameter_info )
-			{
-				int nparams = system->GetNumberOfParameters();
-				
-				cout << "\n";
-				cout << "Parameter info:\n";
-				cout << "================================\n";
-				for ( int ix=0; ix < nparams; ix++ )
-				{
-					std::string parm_name = system->GetParameterName( ix );
-					float parm_value = system->GetParameterValue( ix );
-					cout << parm_name << "=" << parm_value << "\n";
-				}
-				cout << "================================\n";
-			}
-			
-			if ( print_render_settings )
-			{
-				cout << "\n";
-				cout << "Render settings:\n";
-				cout << "================================\n";
-				
-				// A good example cast, left as a relic:
-				//AbstractRD* rdPlayer = dynamic_cast<AbstractRD*>(system);
-				//FormulaOpenCLImageRD* rdPlayer = dynamic_cast<FormulaOpenCLImageRD*>(system);				
-				//Properties *render_settings = rdPlayer->render_settings;
-				
-				int num_properties = render_settings.GetNumberOfProperties();
-				cout << "Number of properties is: " << num_properties << "\n";
-				for (int i=0;i<num_properties;i++)
-				{
-					Property this_property = render_settings.GetProperty( i );
-					
-					std::string property_name = this_property.GetName();
-					std::string property_type = this_property.GetType();
-					
-					cout << "    name: " << property_name << ", type: " << property_type << ", value:";
-					if (property_type == "int")
-					{
-						int property_value = this_property.GetInt();
-						cout << " " << property_value << "\n";
-					} else if (property_type == "bool") {
-						bool property_value = this_property.GetBool();
-						cout << " " << property_value << "\n";
-					} else if (property_type == "float") {
-						float property_value = this_property.GetFloat();
-						cout << " " << property_value << "\n";
-					} else if (property_type == "color") {
-						float property_value_r, property_value_g, property_value_b;
-						this_property.GetColor( property_value_r, property_value_g, property_value_b);
-						cout << " (" << property_value_r << "," << property_value_g << "," << property_value_b << ")\n";
-					} else if (property_type == "chemical") {
-						std::string property_value = this_property.GetChemical();
-						cout << " " << property_value << "\n";
-					} else if (property_type == "axis") {
-						std::string property_value = this_property.GetAxis();
-						cout << " " << property_value << "\n";
-					}
-				}
-				cout << "================================\n";
-			}
-			
-			if ( print_formula_description )
-			{
-				cout << "\n";
-				cout << "Formula description:\n";
-				cout << "================================\n";
-				cout << system->GetDescription();
-				cout << "================================\n";
-			}
-			
-			if ( print_initial_state_images )
-			{
-				int num_chemicals = system->GetNumberOfChemicals();
-				cout << "\n";
-				cout << "Parameter initial-state images:\n";
-				cout << "================================\n";
-				// I'm just going to gloss over numberOfScalarComponents for the moment! (just hope it's always 1 or above!)
-				// so given that, in theory num_chemicals and nc should be equal!
-				
-				// Update to get everything initialised (and copy in the initial states)..
-				system->Update(0);
-				
-				for ( int ix=0; ix < num_chemicals; ix++ )
-				{
-					cout << "\n";
-					cout << "nchem: " << ix << "\n";
-					OpenCLImageRD *isystem = dynamic_cast< OpenCLImageRD* >(system);
-					
-					cout << "xres=" << system->GetX() << "\n";
-					cout << "yres=" << system->GetY() << "\n";
-					cout << "zres=" << system->GetZ() << "\n";
-					
-					// not in bytes!
-					unsigned long reagent_block_size = system->GetX() * system->GetY() * system->GetZ();
-					
-					cout << "Reagent block size is: " << reagent_block_size << "\n";
-					float *rd_data = new float[reagent_block_size];
-					
-					isystem->GetFromOpenCLBuffers( rd_data, ix );
-					
-					cout << "\nRD data for reagent " << ix << ": [ ";
-					for (unsigned long rix=0; rix<reagent_block_size; rix++)
-					{
-						cout << rd_data[rix];
-						if ( rix < reagent_block_size-1 )
-						{
-							cout << ",";
-						}
-					}
-					cout << " ]\n";
-					delete rd_data;
-				}
-				cout << "================================\n";
-			}
-		} catch(const exception& e) {
-			cout << "Error creating system!:\n" << e.what() << "\n"; 
+            system->Update( 0 );
+            if (verbose)
+            {
+                cout << "System updated to zeroth step..\n";
+            }
 
-			void* callstack[128];
-			int i, frames = backtrace( callstack, 128 );
-			char** strs = backtrace_symbols( callstack, frames );
-			for (i = 0; i < frames; ++i) 
-			{
-				printf( "%s\n", strs[i] );
-			}
-			free(strs);
-			
-			cout << "Ignoring exception.\n";
-		}
-		
+            if ( print_reagent_info )
+            {
+                int num_chemicals = system->GetNumberOfChemicals();
+                int xres = system->GetX();
+                int yres = system->GetY();
+                int zres = system->GetZ();
+                int arena_dimensionality = system->GetArenaDimensionality();
+                cout << "\n";
+                cout << "Reagent info:\n";
+                printSeparator();
+                //cout << "================================\n";
+                cout << "num_chemicals=" << num_chemicals << "\n";
+                cout << "arena_dimensionality=" << arena_dimensionality << "\n";
+                cout << "xres=" << xres << "\n";
+                cout << "yres=" << yres << "\n";
+                cout << "zres=" << zres << "\n";
+                cout << "================================\n";
+            }
+
+            if ( print_kernel )
+            {
+                cout << "\n";
+                cout << "Kernel source:\n";
+                cout << "================================\n";
+                cout << system->GetKernel();
+                cout << "================================\n";
+            }
+
+            if ( print_formula )
+            {
+                cout << "\n";
+                cout << "Kernel formula:\n";
+                cout << "================================\n";
+                // Maybe work out how to strip leading whitespace from lines in this:
+                cout << system->GetFormula();
+                cout << "================================\n";
+            }
+
+            if ( print_parameter_info )
+            {
+                int nparams = system->GetNumberOfParameters();
+
+                cout << "\n";
+                cout << "Parameter info:\n";
+                cout << "================================\n";
+                for ( int ix=0; ix < nparams; ix++ )
+                {
+                    std::string parm_name = system->GetParameterName( ix );
+                    float parm_value = system->GetParameterValue( ix );
+                    cout << parm_name << "=" << parm_value << "\n";
+                }
+                cout << "================================\n";
+            }
+
+            if ( print_render_settings )
+            {
+                cout << "\n";
+                cout << "Render settings:\n";
+                cout << "================================\n";
+
+                // A good example cast, left as a relic:
+                //AbstractRD* rdPlayer = dynamic_cast<AbstractRD*>(system);
+                //FormulaOpenCLImageRD* rdPlayer = dynamic_cast<FormulaOpenCLImageRD*>(system);
+                //Properties *render_settings = rdPlayer->render_settings;
+
+                int num_properties = render_settings.GetNumberOfProperties();
+                cout << "Number of properties is: " << num_properties << "\n";
+                for (int i=0;i<num_properties;i++)
+                {
+                    Property this_property = render_settings.GetProperty( i );
+
+                    std::string property_name = this_property.GetName();
+                    std::string property_type = this_property.GetType();
+
+                    cout << "    name: " << property_name << ", type: " << property_type << ", value:";
+                    if (property_type == "int")
+                    {
+                        int property_value = this_property.GetInt();
+                        cout << " " << property_value << "\n";
+                    } else if (property_type == "bool") {
+                        bool property_value = this_property.GetBool();
+                        cout << " " << property_value << "\n";
+                    } else if (property_type == "float") {
+                        float property_value = this_property.GetFloat();
+                        cout << " " << property_value << "\n";
+                    } else if (property_type == "color") {
+                        float property_value_r, property_value_g, property_value_b;
+                        this_property.GetColor( property_value_r, property_value_g, property_value_b);
+                        cout << " (" << property_value_r << "," << property_value_g << "," << property_value_b << ")\n";
+                    } else if (property_type == "chemical") {
+                        std::string property_value = this_property.GetChemical();
+                        cout << " " << property_value << "\n";
+                    } else if (property_type == "axis") {
+                        std::string property_value = this_property.GetAxis();
+                        cout << " " << property_value << "\n";
+                    }
+                }
+                cout << "================================\n";
+            }
+
+            if ( print_formula_description )
+            {
+                cout << "\n";
+                cout << "Formula description:\n";
+                cout << "================================\n";
+                cout << system->GetDescription();
+                cout << "================================\n";
+            }
+
+            if ( print_initial_state_images )
+            {
+                int num_chemicals = system->GetNumberOfChemicals();
+                cout << "\n";
+                cout << "Parameter initial-state images:\n";
+                cout << "================================\n";
+                // I'm just going to gloss over numberOfScalarComponents for the moment! (just hope it's always 1 or above!)
+                // so given that, in theory num_chemicals and nc should be equal!
+
+                // Update to get everything initialised (and copy in the initial states)..
+                system->Update(0);
+
+                for ( int ix=0; ix < num_chemicals; ix++ )
+                {
+                    cout << "\n";
+                    cout << "nchem: " << ix << "\n";
+                    OpenCLImageRD *isystem = dynamic_cast< OpenCLImageRD* >(system);
+
+                    cout << "xres=" << system->GetX() << "\n";
+                    cout << "yres=" << system->GetY() << "\n";
+                    cout << "zres=" << system->GetZ() << "\n";
+
+                    // not in bytes!
+                    unsigned long reagent_block_size = system->GetX() * system->GetY() * system->GetZ();
+
+                    cout << "Reagent block size is: " << reagent_block_size << "\n";
+                    float *rd_data = new float[reagent_block_size];
+
+                    isystem->GetFromOpenCLBuffers( rd_data, ix );
+
+                    cout << "\nRD data for reagent " << ix << ": [ ";
+                    for (unsigned long rix=0; rix<reagent_block_size; rix++)
+                    {
+                        cout << rd_data[rix];
+                        if ( rix < reagent_block_size-1 )
+                        {
+                            cout << ",";
+                        }
+                    }
+                    cout << " ]\n";
+                    delete rd_data;
+                }
+                cout << "================================\n";
+            }
+        } catch(const exception& e) {
+            cout << "Error creating system!:\n" << e.what() << "\n";
+
+            /* TODO: find equivalent of backtrace that works on all supported platforms
+            void* callstack[128];
+            int i, frames = backtrace( callstack, 128 );
+            char** strs = backtrace_symbols( callstack, frames );
+            for (i = 0; i < frames; ++i)
+            {
+                printf( "%s\n", strs[i] );
+            }
+            free(strs);
+            */
+
+            cout << "Ignoring exception.\n";
+        }
+
         if( warn_to_update )
             cout << "This pattern was created with a newer version of Ready. You should update your copy.\n";
-		
-		if ( numiter > 0 )
-		{
-        	cout << "Run the simulation for " << numiter << " steps...\n";
-        	system->Update( numiter );
 
-			if ( vm.count("vti-out") )
-			{
-	        	// save something out
-    	    	cout << "Saving file as " << vti_out << " ...\n";
-				try {
-		        	system->SaveFile( vti_out.c_str(), render_settings, false );
-				} catch(const exception& e) { //doesn't catch segfaults! :/
-					cout << "Something went wrong when saving file to: " << vti_out.c_str() << "\n";
-					cout << e.what() << "\n";
-				}
-			} else {
-				cout << "Output file not specified, not saving anything.\n";
-			}
-		} else { 
-			if (verbose)
-			{
-				cout << "Zero iterations, simulation skipped.\n";
-			}
-		}
+        if ( numiter > 0 )
+        {
+            cout << "Run the simulation for " << numiter << " steps...\n";
+            system->Update( numiter );
+
+            if ( vm.count("vti-out") )
+            {
+                // save something out
+                cout << "Saving file as " << vti_out << " ...\n";
+                try {
+                    system->SaveFile( vti_out.c_str(), render_settings, false );
+                } catch(const exception& e) { //doesn't catch segfaults! :/
+                    cout << "Something went wrong when saving file to: " << vti_out.c_str() << "\n";
+                    cout << e.what() << "\n";
+                }
+            } else {
+                cout << "Output file not specified, not saving anything.\n";
+            }
+        } else {
+            if (verbose)
+            {
+                cout << "Zero iterations, simulation skipped.\n";
+            }
+        }
     }
     catch(const exception& e)
     {
@@ -475,9 +477,7 @@ int main(int argc,char *argv[])
 
 void InitializeDefaultRenderSettings(Properties &render_settings)
 {
-    // TODO: code duplication here from frame.cpp, not sure how best to merge
-	// .. fixed!
-	render_settings.SetDefaultRenderSettings();
+    render_settings.SetDefaultRenderSettings();
 }
 
 // -------------------------------------------------------------------------------------------------------------

--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -108,11 +108,10 @@ int main(int argc,char *argv[])
             cout << "\nIt looks like one of the required arguments is missing or malformed:\n";
             cout << e.what() << "\n\n";
             cout << "Here's the help:\n";
-        } else {
-            cout << "\n" << blurb << "\n";
-            cout << "\n" << desc << "\n";
-            return 1;
         }
+        cout << "\n" << blurb << "\n";
+        cout << "\n" << desc << "\n";
+        return 1;
     }
 
     int numiter = 1000;

--- a/src/readybase/OpenCLImageRD.cpp
+++ b/src/readybase/OpenCLImageRD.cpp
@@ -236,10 +236,10 @@ void OpenCLImageRD::ReadFromOpenCLBuffers()
 
 void OpenCLImageRD::GetFromOpenCLBuffers( float* dest, int chemical_id )
 {
-  // read from opencl buffers into our image
-	const unsigned long MEM_SIZE = sizeof(float) * this->GetX() * this->GetY() * this->GetZ();
-	cl_int ret = clEnqueueReadBuffer(this->command_queue,this->buffers[this->iCurrentBuffer][chemical_id], CL_TRUE, 0, MEM_SIZE, dest, 0, NULL, NULL);
-  //throwOnError(ret,"OpenCLImageRD::GetFromOpenCLBuffers : buffer reading failed: ");
+    // read from opencl buffers into our image
+    const unsigned long MEM_SIZE = sizeof(float) * this->GetX() * this->GetY() * this->GetZ();
+    cl_int ret = clEnqueueReadBuffer(this->command_queue,this->buffers[this->iCurrentBuffer][chemical_id], CL_TRUE, 0, MEM_SIZE, dest, 0, NULL, NULL);
+    throwOnError(ret,"OpenCLImageRD::GetFromOpenCLBuffers : buffer reading failed: ");
 }
 
 // ----------------------------------------------------------------------------------------------------------------

--- a/src/readybase/OpenCLImageRD.cpp
+++ b/src/readybase/OpenCLImageRD.cpp
@@ -234,6 +234,16 @@ void OpenCLImageRD::ReadFromOpenCLBuffers()
 
 // ----------------------------------------------------------------------------------------------------------------
 
+void OpenCLImageRD::GetFromOpenCLBuffers( float* dest, int chemical_id )
+{
+  // read from opencl buffers into our image
+	const unsigned long MEM_SIZE = sizeof(float) * this->GetX() * this->GetY() * this->GetZ();
+	cl_int ret = clEnqueueReadBuffer(this->command_queue,this->buffers[this->iCurrentBuffer][chemical_id], CL_TRUE, 0, MEM_SIZE, dest, 0, NULL, NULL);
+  //throwOnError(ret,"OpenCLImageRD::GetFromOpenCLBuffers : buffer reading failed: ");
+}
+
+// ----------------------------------------------------------------------------------------------------------------
+
 void OpenCLImageRD::TestFormula(std::string program_string)
 {
     this->TestKernel(this->AssembleKernelSourceFromFormula(program_string));

--- a/src/readybase/OpenCLImageRD.hpp
+++ b/src/readybase/OpenCLImageRD.hpp
@@ -45,7 +45,8 @@ class OpenCLImageRD : public ImageRD, public OpenCL_MixIn
 
         virtual void Undo();
         virtual void Redo();
-
+        virtual void GetFromOpenCLBuffers( float* dest, int chemical_id );
+		
     protected:
 
         virtual void CopyFromImage(vtkImageData* im);

--- a/src/readybase/Properties.cpp
+++ b/src/readybase/Properties.cpp
@@ -135,3 +135,33 @@ bool Properties::IsProperty(const std::string& name)
     }
     return false;
 }
+
+void Properties::SetDefaultRenderSettings( )
+{
+    this->DeleteAllProperties();
+    this->AddProperty( Property("surface_color","color",1.0f,1.0f,1.0f) ); // RGB [0,1]
+    this->AddProperty( Property("color_low","color",0.0f,0.0f,1.0f) );
+    this->AddProperty( Property("color_high","color",1.0f,0.0f,0.0f) );
+    this->AddProperty( Property("show_color_scale",true) );
+    this->AddProperty( Property("show_multiple_chemicals",true) );
+    this->AddProperty( Property("active_chemical","chemical","a") );
+    this->AddProperty( Property("low",0.0f) );
+    this->AddProperty( Property("high",1.0f) );
+    this->AddProperty( Property("vertical_scale_1D",30.0f) );
+    this->AddProperty( Property("vertical_scale_2D",15.0f) );
+    this->AddProperty( Property("contour_level",0.25f) );
+    this->AddProperty( Property("use_wireframe",false) );
+    this->AddProperty( Property("show_cell_edges",false) );
+    this->AddProperty( Property("show_bounding_box",true) );
+    this->AddProperty( Property("slice_3D",true) );
+    this->AddProperty( Property("slice_3D_axis","axis","z") );
+    this->AddProperty( Property("slice_3D_position",0.5f) ); // [0,1]
+    this->AddProperty( Property("show_displacement_mapped_surface",true) );
+    this->AddProperty( Property("color_displacement_mapped_surface",true) );
+    this->AddProperty( Property("use_image_interpolation",true) );
+    this->AddProperty( Property("timesteps_per_render",100) );
+    this->AddProperty( Property("show_phase_plot",false) );
+    this->AddProperty( Property("phase_plot_x_axis","chemical","a") );
+    this->AddProperty( Property("phase_plot_y_axis","chemical","b") );
+    this->AddProperty( Property("phase_plot_z_axis","chemical","c") );
+}

--- a/src/readybase/Properties.hpp
+++ b/src/readybase/Properties.hpp
@@ -79,12 +79,11 @@ class Property : public XML_Object
 /// A set of Property instances that can be saved/loaded to/from XML.
 class Properties : public XML_Object
 {
-    public: 
+    public:
 
         Properties(std::string set_name) : XML_Object(NULL),set_name(set_name) {}
         void OverwriteFromXML(vtkXMLDataElement* node);
         virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
-
 
         int GetNumberOfProperties() const { return (int)this->properties.size(); }
         const Property& GetProperty(int i) const { return this->properties[i]; }
@@ -94,9 +93,9 @@ class Properties : public XML_Object
         bool IsProperty(const std::string& name);
         void DeleteAllProperties() { this->properties.clear(); }
         void SetDefaultRenderSettings();
-		
+
     protected:
-    
+
         std::vector<Property> properties;
         std::string set_name; ///< used for saving to XML
 };

--- a/src/readybase/Properties.hpp
+++ b/src/readybase/Properties.hpp
@@ -85,6 +85,7 @@ class Properties : public XML_Object
         void OverwriteFromXML(vtkXMLDataElement* node);
         virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
 
+
         int GetNumberOfProperties() const { return (int)this->properties.size(); }
         const Property& GetProperty(int i) const { return this->properties[i]; }
         const Property& GetProperty(const std::string& name) const;
@@ -92,7 +93,8 @@ class Properties : public XML_Object
         void AddProperty(Property p);
         bool IsProperty(const std::string& name);
         void DeleteAllProperties() { this->properties.clear(); }
-
+        void SetDefaultRenderSettings();
+		
     protected:
     
         std::vector<Property> properties;


### PR DESCRIPTION
In this revision, Ready's commandline utility 'rdy', includes boost as a link dependency, and can do much more than it did before.

I will soon also be able to contribute several Houdini Digital Assets (HDA's) that will allow you (by pointing at this rdy binary) to import OpenCLImageRD-based formulas directly into Houdini as Gas OpenCL Dops.

This is what the help (-h or --help argument) says in this version:
```
========================
Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.

It responds to various commandline arguments to load and print out parts of the system,
and can also still be used (like it used to work) to iterate the system to a specified number
of steps, and save it to a new vti file.

The various print options can facilitate the import of ready simulations into other applications, (such
as Houdini), without the need to actually link the ready libraries. This includes reagent initial-states,
(via -m), so be ready for some large lumps of text on stdout when using that argument.

Do let the Ready team know if there is something that you wish to print that currently isn't supported.

Options:
  -h [ --help ]                        Print the help message
  -n [ --num-iterations ] arg (=0)     Number of iterations to run before
                                       saving
  -k [ --print-kernel ]                Print (full) OpenCL kernel source (when
                                       possible)
  -f [ --print-formula ]               Print kernel formula (when possible)
  -r [ --print-reagent-info ]          Print reagent info
  -p [ --print-parameter-info ]        Print parameter info
  -s [ --print-render-settings ]       Print render Settings
  -d [ --print-formula-description ]   Print formula Description
  -m [ --print-initial-state-images ]  Print initial state images (Warning: May
                                       be large!)
  -i [ --vti-in ] arg                  VTI file to load (required)
  -o [ --vti-out ] arg                 VTI file to save (optional)
  -l [ --opencl-platform ] arg         OpenCL platform number (Currently will
                                       crash if incorrect!)
  -g [ --opencl-device ] arg           OpenCL device number (Currently will
                                       crash if incorrect!)
  -v [ --verbose ]                     Verbose output.
========================
```