### PR TITLE
Using override on overriding functions, to guard against typos.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,7 @@ endif()
 if( APPLE )
   # support macOS 10.10 or later
   add_definitions( -mmacosx-version-min=10.10 )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -stdlib=libc++ -Wno-nullability-completeness-on-arrays -Wno-inconsistent-missing-override")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-nullability-completeness-on-arrays")
 endif()
 if( APPLE OR UNIX )
   # use same settings as in makefiles

--- a/src/gui/wxVTKRenderWindowInteractor.h
+++ b/src/gui/wxVTKRenderWindowInteractor.h
@@ -153,8 +153,8 @@ class wxVTKRenderWindowInteractor : public wxWindow, public vtkRenderWindowInter
 
 #if VTK_MAJOR_VERSION > 5 || (VTK_MAJOR_VERSION == 5 && VTK_MINOR_VERSION >= 2)
   protected:
-    virtual int InternalCreateTimer(int timerId, int timerType, unsigned long duration) override;
-    virtual int InternalDestroyTimer(int platformTimerId) override;
+    int InternalCreateTimer(int timerId, int timerType, unsigned long duration) override;
+    int InternalDestroyTimer(int platformTimerId) override;
 #endif
 
   protected:

--- a/src/readybase/AbstractRD.hpp
+++ b/src/readybase/AbstractRD.hpp
@@ -223,6 +223,8 @@ class AbstractRD
         /// Advance the RD system by n timesteps.
         virtual void InternalUpdate(int n_steps)=0;
 
+        virtual void AddPhasePlot(vtkRenderer* pRenderer, float scaling, float low, float high, float posX, float posY, float posZ,
+            int iChemX, int iChemY, int iChemZ) =0;
         virtual void FlipPaintAction(PaintAction& cca) =0; ///< Undo/redo this paint action.
         void StorePaintAction(int iChemical,int iCell,float old_val); ///< Implementations call this when performing undo-able paint actions.
 

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -20,8 +20,8 @@
 
 /// An RD system that uses an OpenCL formula snippet.
 /** An N-dimensional (1D,2D,3D) OpenCL RD implementations with n chemicals
- *  specified as a short formula involving delta_a, laplacian_a, etc. 
- *  implemented with Euler integration, a basic finite difference stencil 
+ *  specified as a short formula involving delta_a, laplacian_a, etc.
+ *  implemented with Euler integration, a basic finite difference stencil
  *  and float4 blocks for speed */
 class FormulaOpenCLImageRD : public OpenCLImageRD
 {
@@ -29,23 +29,23 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
 
         FormulaOpenCLImageRD(int opencl_platform,int opencl_device,int data_type);
 
-        virtual void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update);
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const;
+        void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update) override;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const override;
 
-        virtual std::string GetRuleType() const { return "formula"; }
+        std::string GetRuleType() const override { return "formula"; }
 
-        virtual int GetBlockSizeX() const { return 4; } // we use float4 in a 4x1x1 block
+        int GetBlockSizeX() const override { return 4; } // we use float4 in a 4x1x1 block
 
-        virtual std::string AssembleKernelSourceFromFormula(std::string formula) const;
+        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel
-        virtual void AddParameter(const std::string& name,float val);
-        virtual void DeleteParameter(int iParam);
-        virtual void DeleteAllParameters();
-        virtual void SetParameterName(int iParam,const std::string& s);
-        virtual void SetParameterValue(int iParam,float val);
+        void AddParameter(const std::string& name,float val) override;
+        void DeleteParameter(int iParam) override;
+        void DeleteAllParameters() override;
+        void SetParameterName(int iParam,const std::string& s) override;
+        void SetParameterValue(int iParam,float val) override;
 
-        virtual bool HasEditableWrapOption() const { return true; }
-        virtual void SetWrap(bool w);
-        virtual bool HasEditableDataType() const { return true; }
+        bool HasEditableWrapOption() const override { return true; }
+        void SetWrap(bool w) override;
+        bool HasEditableDataType() const override { return true; }
 };

--- a/src/readybase/FormulaOpenCLMeshRD.hpp
+++ b/src/readybase/FormulaOpenCLMeshRD.hpp
@@ -25,19 +25,19 @@ class FormulaOpenCLMeshRD : public OpenCLMeshRD
 
         FormulaOpenCLMeshRD(int opencl_platform,int opencl_device,int data_type);
 
-        virtual void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update);
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const;
+        void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update) override;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const override;
 
-        virtual std::string GetRuleType() const { return "formula"; }
+        std::string GetRuleType() const override { return "formula"; }
 
-        virtual std::string AssembleKernelSourceFromFormula(std::string formula) const;
+        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel
-        virtual void AddParameter(const std::string& name,float val);
-        virtual void DeleteParameter(int iParam);
-        virtual void DeleteAllParameters();
-        virtual void SetParameterName(int iParam,const std::string& s);
-        virtual void SetParameterValue(int iParam,float val);
+        void AddParameter(const std::string& name,float val) override;
+        void DeleteParameter(int iParam) override;
+        void DeleteAllParameters() override;
+        void SetParameterName(int iParam,const std::string& s) override;
+        void SetParameterValue(int iParam,float val) override;
 
-        virtual bool HasEditableDataType() const { return true; }
+        bool HasEditableDataType() const override { return true; }
 };

--- a/src/readybase/FullKernelOpenCLImageRD.hpp
+++ b/src/readybase/FullKernelOpenCLImageRD.hpp
@@ -28,24 +28,24 @@ class FullKernelOpenCLImageRD : public OpenCLImageRD
         FullKernelOpenCLImageRD(int opencl_platform,int opencl_device,int data_type);
         FullKernelOpenCLImageRD(const OpenCLImageRD& source); // copy construct from another
 
-        virtual void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update);
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const;
+        void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update) override;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const override;
 
-        virtual std::string GetRuleType() const { return "kernel"; }
+        std::string GetRuleType() const override { return "kernel"; }
 
-        virtual bool HasEditableBlockSize() const { return true; }
-        virtual int GetBlockSizeX() const { return this->block_size[0]; }
-        virtual int GetBlockSizeY() const { return this->block_size[1]; }
-        virtual int GetBlockSizeZ() const { return this->block_size[2]; }
-        virtual void SetBlockSizeX(int n) { this->block_size[0]=n; this->need_reload_formula=true; }
-        virtual void SetBlockSizeY(int n) { this->block_size[1]=n; this->need_reload_formula=true; }
-        virtual void SetBlockSizeZ(int n) { this->block_size[2]=n; this->need_reload_formula=true; }
+        bool HasEditableBlockSize() const override { return true; }
+        int GetBlockSizeX() const override { return this->block_size[0]; }
+        int GetBlockSizeY() const override { return this->block_size[1]; }
+        int GetBlockSizeZ() const override { return this->block_size[2]; }
+        void SetBlockSizeX(int n) override { this->block_size[0]=n; this->need_reload_formula=true; }
+        void SetBlockSizeY(int n) override { this->block_size[1]=n; this->need_reload_formula=true; }
+        void SetBlockSizeZ(int n) override { this->block_size[2]=n; this->need_reload_formula=true; }
 
-        virtual std::string AssembleKernelSourceFromFormula(std::string formula) const;
-        
-        virtual bool HasEditableDataType() const { return false; }
+        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
+
+        bool HasEditableDataType() const override { return false; }
 
 protected:
-    
+
         int block_size[3];
 };

--- a/src/readybase/FullKernelOpenCLMeshRD.hpp
+++ b/src/readybase/FullKernelOpenCLMeshRD.hpp
@@ -26,12 +26,12 @@ class FullKernelOpenCLMeshRD : public OpenCLMeshRD
         FullKernelOpenCLMeshRD(int opencl_platform,int opencl_device,int data_type);
         FullKernelOpenCLMeshRD(const OpenCLMeshRD& source); // copy construct from source
 
-        virtual void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update);
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const;
+        void InitializeFromXML(vtkXMLDataElement* rd,bool& warn_to_update) override;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML(bool generate_initial_pattern_when_loading) const override;
 
-        virtual std::string GetRuleType() const { return "kernel"; }
+        std::string GetRuleType() const override { return "kernel"; }
 
-        virtual std::string AssembleKernelSourceFromFormula(std::string formula) const;
+        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
 
-        virtual bool HasEditableDataType() const { return false; }
+        bool HasEditableDataType() const override { return false; }
 };

--- a/src/readybase/GrayScottImageRD.hpp
+++ b/src/readybase/GrayScottImageRD.hpp
@@ -25,13 +25,13 @@ class InbuiltImageRD : public ImageRD
     public:
         InbuiltImageRD(int data_type) : ImageRD(data_type) {}
 
-        std::string GetRuleType() const { return "inbuilt"; }
+        std::string GetRuleType() const override { return "inbuilt"; }
 
-        virtual bool HasEditableFormula() const { return false; }
-        virtual bool HasEditableNumberOfChemicals() const { return false; }
+        bool HasEditableFormula() const override { return false; }
+        bool HasEditableNumberOfChemicals() const override { return false; }
 
-        virtual bool HasEditableWrapOption() const { return true; }
-        virtual bool HasEditableDataType() const { return false; }
+        bool HasEditableWrapOption() const override { return true; }
+        bool HasEditableDataType() const override { return false; }
 };
 
 /// An inbuilt implementation: n-dimensional Gray-Scott.
@@ -48,9 +48,9 @@ class GrayScottImageRD : public InbuiltImageRD
 
     protected:
 
-        virtual void AllocateImages(int x,int y,int z,int nc,int data_type);
+        void AllocateImages(int x,int y,int z,int nc,int data_type) override;
 
-        virtual void InternalUpdate(int n_steps);
+        void InternalUpdate(int n_steps) override;
 
         void DeleteBuffers();
 };

--- a/src/readybase/GrayScottMeshRD.hpp
+++ b/src/readybase/GrayScottMeshRD.hpp
@@ -26,11 +26,11 @@ class InbuiltMeshRD : public MeshRD
 
         InbuiltMeshRD(int data_type) : MeshRD(data_type) {}
 
-        virtual std::string GetRuleType() const { return "inbuilt"; }
+        std::string GetRuleType() const override { return "inbuilt"; }
 
-        virtual bool HasEditableFormula() const { return false; }
-        virtual bool HasEditableNumberOfChemicals() const { return false; }
-        virtual bool HasEditableDataType() const { return false; }
+        bool HasEditableFormula() const override { return false; }
+        bool HasEditableNumberOfChemicals() const override { return false; }
+        bool HasEditableDataType() const override { return false; }
 };
 
 /// A non-OpenCL mesh implementation, just as an example.
@@ -41,11 +41,11 @@ class GrayScottMeshRD : public InbuiltMeshRD
         GrayScottMeshRD();
 
         void SetNumberOfChemicals(int n, bool reallocate_storage = false) override;
-        virtual void CopyFromMesh(vtkUnstructuredGrid *mesh2);
+        void CopyFromMesh(vtkUnstructuredGrid *mesh2) override;
 
     protected:
 
-        virtual void InternalUpdate(int n_steps);
+        void InternalUpdate(int n_steps) override;
 
     protected:
 

--- a/src/readybase/IO_XML.hpp
+++ b/src/readybase/IO_XML.hpp
@@ -43,9 +43,9 @@ class RD_XMLImageReader : public vtkXMLImageDataReader
         vtkXMLDataElement* GetRDElement();
         bool ShouldGenerateInitialPatternWhenLoading();
 
-    protected:  
+    protected:
 
-        RD_XMLImageReader() {} 
+        RD_XMLImageReader() {}
 
 };
 
@@ -64,9 +64,9 @@ class RD_XMLUnstructuredGridReader : public vtkXMLUnstructuredGridReader
         vtkXMLDataElement* GetRDElement();
         bool ShouldGenerateInitialPatternWhenLoading();
 
-    protected:  
+    protected:
 
-        RD_XMLUnstructuredGridReader() {} 
+        RD_XMLUnstructuredGridReader() {}
 
 };
 
@@ -84,13 +84,13 @@ class RD_XMLImageWriter : public vtkXMLImageDataWriter
         void SetRenderSettings(const Properties* settings) { this->render_settings = settings; }
         void GenerateInitialPatternWhenLoading() { this->generate_initial_pattern_when_loading = true; }
 
-    protected:  
+    protected:
 
-        RD_XMLImageWriter() : system(NULL), generate_initial_pattern_when_loading(false) {} 
+        RD_XMLImageWriter() : system(NULL), generate_initial_pattern_when_loading(false) {}
 
         static vtkSmartPointer<vtkXMLDataElement> BuildRDSystemXML(ImageRD* system);
 
-        virtual int WritePrimaryElement(ostream& os,vtkIndent indent) override;
+        int WritePrimaryElement(ostream& os,vtkIndent indent) override;
 
     protected:
 
@@ -113,13 +113,13 @@ class RD_XMLUnstructuredGridWriter : public vtkXMLUnstructuredGridWriter
         void SetRenderSettings(const Properties* settings) { this->render_settings = settings; }
         void GenerateInitialPatternWhenLoading() { this->generate_initial_pattern_when_loading = true; }
 
-    protected:  
+    protected:
 
-        RD_XMLUnstructuredGridWriter() : system(NULL), generate_initial_pattern_when_loading(false) {} 
+        RD_XMLUnstructuredGridWriter() : system(NULL), generate_initial_pattern_when_loading(false) {}
 
         static vtkSmartPointer<vtkXMLDataElement> BuildRDSystemXML(MeshRD* system);
 
-        virtual int WritePrimaryElement(ostream& os,vtkIndent indent) override;
+        int WritePrimaryElement(ostream& os,vtkIndent indent) override;
 
     protected:
 

--- a/src/readybase/ImageRD.hpp
+++ b/src/readybase/ImageRD.hpp
@@ -33,26 +33,27 @@ class ImageRD : public AbstractRD
     public:
 
         ImageRD(int data_type);
-        virtual ~ImageRD();
+        ~ImageRD();
 
-        virtual void SaveFile(const char* filename,const Properties& render_settings,
-            bool generate_initial_pattern_when_loading) const;
+        void SaveFile(const char* filename,
+            const Properties& render_settings,
+            bool generate_initial_pattern_when_loading) const override;
 
-        virtual void Update(int n_steps);
+        void Update(int n_steps) override;
 
-        virtual bool HasEditableDimensions() const { return true; }
-        virtual float GetX() const;
-        virtual float GetY() const;
-        virtual float GetZ() const;
-        virtual void SetDimensions(int x,int y,int z);
-        virtual void SetDimensionsAndNumberOfChemicals(int x,int y,int z,int nc);
+        bool HasEditableDimensions() const  override { return true; }
+        float GetX() const override;
+        float GetY() const override;
+        float GetZ() const override;
+        void SetDimensions(int x,int y,int z) override;
+        void SetDimensionsAndNumberOfChemicals(int x,int y,int z,int nc);
 
-        virtual int GetNumberOfCells() const;
+        int GetNumberOfCells() const override;
 
         void SetNumberOfChemicals(int n, bool reallocate_storage = false) override;
 
-        virtual void GenerateInitialPattern();
-        virtual void BlankImage(float value = 0.0f);
+        void GenerateInitialPattern() override;
+        void BlankImage(float value = 0.0f) override;
         void GetImage(vtkImageData* im) const;
         virtual void CopyFromImage(vtkImageData* im);
         virtual void CopyFromMesh(
@@ -62,24 +63,24 @@ class ImageRD : public AbstractRD
             const size_t largest_dimension,
             const float value_inside,
             const float value_outside);
-        virtual void SaveStartingPattern();
-        virtual void RestoreStartingPattern();
+        void SaveStartingPattern() override;
+        void RestoreStartingPattern() override;
 
-        virtual void InitializeRenderPipeline(vtkRenderer* pRenderer,const Properties& render_settings);
+        void InitializeRenderPipeline(vtkRenderer* pRenderer,const Properties& render_settings) override;
 
-        virtual std::string GetFileExtension() const { return ImageRD::GetFileExtensionStatic(); }
+        std::string GetFileExtension() const override { return ImageRD::GetFileExtensionStatic(); }
         static std::string GetFileExtensionStatic() { return "vti"; }
 
-        virtual void GetAsMesh(vtkPolyData *out,const Properties& render_settings) const;
-        virtual void GetAs2DImage(vtkImageData *out,const Properties& render_settings) const;
-        virtual void SetFrom2DImage(int iChemical, vtkImageData *im);
-        virtual bool Is2DImageAvailable() const { return true; }
+        void GetAsMesh(vtkPolyData *out,const Properties& render_settings) const override;
+        void GetAs2DImage(vtkImageData *out,const Properties& render_settings) const override;
+        void SetFrom2DImage(int iChemical, vtkImageData *im) override;
+        bool Is2DImageAvailable() const override { return true; }
 
-        virtual float GetValue(float x,float y,float z,const Properties& render_settings);
-        virtual void SetValue(float x,float y,float z,float val,const Properties& render_settings);
-        virtual void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings);
+        float GetValue(float x,float y,float z,const Properties& render_settings) override;
+        void SetValue(float x,float y,float z,float val,const Properties& render_settings) override;
+        void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings) override;
 
-        virtual size_t GetMemorySize() const;
+        size_t GetMemorySize() const override;
 
     protected:
 
@@ -95,6 +96,9 @@ class ImageRD : public AbstractRD
 
         vtkImageData* GetImage(int iChemical) const;
 
+        void AddPhasePlot(vtkRenderer* pRenderer,float scaling,float low,float high,float posX,float posY,float posZ,
+                            int iChemX,int iChemY,int iChemZ) override;
+
         /// use to change the dimensions or the number of chemicals
         virtual void AllocateImages(int x,int y,int z,int nc,int data_type);
 
@@ -102,9 +106,9 @@ class ImageRD : public AbstractRD
 
         static vtkSmartPointer<vtkImageData> AllocateVTKImage(int x,int y,int z,int data_type);
 
-        virtual int GetArenaDimensionality() const;
+        int GetArenaDimensionality() const override;
 
-        virtual void FlipPaintAction(PaintAction& cca);
+        void FlipPaintAction(PaintAction& cca) override;
 
         // some saved handles into the pipeline, for manual updates to workaround a named arrays problem
         vtkAssignAttribute *assign_attribute_filter;
@@ -115,8 +119,6 @@ class ImageRD : public AbstractRD
         void InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& render_settings);
         void InitializeVTKPipeline_2D(vtkRenderer* pRenderer,const Properties& render_settings);
         void InitializeVTKPipeline_3D(vtkRenderer* pRenderer,const Properties& render_settings);
-        void AddPhasePlot(vtkRenderer* pRenderer,float scaling,float low,float high,float posX,float posY,float posZ,
-                            int iChemX,int iChemY,int iChemZ);
 
     private: // deliberately not implemented, to prevent use
 

--- a/src/readybase/MeshRD.hpp
+++ b/src/readybase/MeshRD.hpp
@@ -32,52 +32,54 @@ class MeshRD : public AbstractRD
     public:
 
         MeshRD(int data_type);
-        virtual ~MeshRD();
+        ~MeshRD();
 
-        virtual void SaveFile(const char* filename,const Properties& render_settings,
-            bool generate_initial_pattern_when_loading) const;
+        void SaveFile(const char* filename,
+            const Properties& render_settings,
+            bool generate_initial_pattern_when_loading) const override;
 
-        virtual void Update(int n_steps);
+        void Update(int n_steps) override;
 
-        virtual float GetX() const;
-        virtual float GetY() const;
-        virtual float GetZ() const;
+        float GetX() const override;
+        float GetY() const override;
+        float GetZ() const override;
 
         void SetNumberOfChemicals(int n, bool reallocate_storage = false) override;
 
-        virtual bool HasEditableFormula() const { return true; }
+        bool HasEditableFormula() const override { return true; }
 
-        virtual std::string GetFileExtension() const { return MeshRD::GetFileExtensionStatic(); }
+        std::string GetFileExtension() const override { return MeshRD::GetFileExtensionStatic(); }
         static std::string GetFileExtensionStatic() { return "vtu"; }
 
-        virtual int GetNumberOfCells() const;
+        int GetNumberOfCells() const override;
 
-        virtual void GenerateInitialPattern();
-        virtual void BlankImage(float value = 0.0f);
+        void GenerateInitialPattern() override;
+        void BlankImage(float value = 0.0f) override;
         virtual void CopyFromMesh(vtkUnstructuredGrid* mesh2);
-        virtual void SaveStartingPattern();
-        virtual void RestoreStartingPattern();
+        void SaveStartingPattern() override;
+        void RestoreStartingPattern() override;
 
-        virtual void InitializeRenderPipeline(vtkRenderer* pRenderer,const Properties& render_settings);
-        void AddPhasePlot(  vtkRenderer* pRenderer,float scaling,float low,float high,float posX,float posY,float posZ,
-                            int iChemX,int iChemY,int iChemZ);
+        void InitializeRenderPipeline(vtkRenderer* pRenderer,const Properties& render_settings) override;
 
-        virtual void GetAsMesh(vtkPolyData *out,const Properties& render_settings) const;
-        virtual void GetAs2DImage(vtkImageData *out,const Properties& render_settings) const;
-        virtual void SetFrom2DImage(int iChemical, vtkImageData *im);
-        virtual bool Is2DImageAvailable() const { return false; }
+        void GetAsMesh(vtkPolyData *out,const Properties& render_settings) const override;
+        void GetAs2DImage(vtkImageData *out,const Properties& render_settings) const override;
+        void SetFrom2DImage(int iChemical, vtkImageData *im) override;
+        bool Is2DImageAvailable() const override { return false; }
 
-        virtual int GetArenaDimensionality() const;
+        int GetArenaDimensionality() const override;
 
-        virtual float GetValue(float x,float y,float z,const Properties& render_settings);
-        virtual void SetValue(float x,float y,float z,float val,const Properties& render_settings);
-        virtual void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings);
+        float GetValue(float x,float y,float z,const Properties& render_settings) override;
+        void SetValue(float x,float y,float z,float val,const Properties& render_settings) override;
+        void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings) override;
 
         void GetMesh(vtkUnstructuredGrid* mesh) const;
 
-        virtual size_t GetMemorySize() const;
+        size_t GetMemorySize() const override;
 
     protected: // functions
+
+        void AddPhasePlot(  vtkRenderer* pRenderer,float scaling,float low,float high,float posX,float posY,float posZ,
+                            int iChemX,int iChemY,int iChemZ) override;
 
         /// work out which cells are neighbors of each other
         void ComputeCellNeighbors(TNeighborhood neighborhood_type);
@@ -87,7 +89,7 @@ class MeshRD : public AbstractRD
 
         void CreateCellLocatorIfNeeded();
 
-        virtual void FlipPaintAction(PaintAction& cca);
+        void FlipPaintAction(PaintAction& cca) override;
 
     protected: // variables
 

--- a/src/readybase/MeshRD.hpp
+++ b/src/readybase/MeshRD.hpp
@@ -84,9 +84,6 @@ class MeshRD : public AbstractRD
         /// work out which cells are neighbors of each other
         void ComputeCellNeighbors(TNeighborhood neighborhood_type);
 
-        /// advance the RD system by n timesteps
-        virtual void InternalUpdate(int n_steps) =0;
-
         void CreateCellLocatorIfNeeded();
 
         void FlipPaintAction(PaintAction& cca) override;

--- a/src/readybase/OpenCLImageRD.cpp
+++ b/src/readybase/OpenCLImageRD.cpp
@@ -234,7 +234,7 @@ void OpenCLImageRD::ReadFromOpenCLBuffers()
 
 // ----------------------------------------------------------------------------------------------------------------
 
-void OpenCLImageRD::GetFromOpenCLBuffers( float* dest, int chemical_id )
+void OpenCLImageRD::GetFromOpenCLBuffers(float* dest, int chemical_id) const
 {
     // read from opencl buffers into our image
     const unsigned long MEM_SIZE = sizeof(float) * this->GetX() * this->GetY() * this->GetZ();

--- a/src/readybase/OpenCLImageRD.hpp
+++ b/src/readybase/OpenCLImageRD.hpp
@@ -29,38 +29,38 @@ class OpenCLImageRD : public ImageRD, public OpenCL_MixIn
 
         OpenCLImageRD(int opencl_platform,int opencl_device,int data_type);
 
-        virtual bool HasEditableFormula() const { return true; }
+        bool HasEditableFormula() const override { return true; }
 
-        virtual void GenerateInitialPattern();
-        virtual void BlankImage(float value = 0.0f);
+        void GenerateInitialPattern() override;
+        void BlankImage(float value = 0.0f) override;
 
-        virtual void TestFormula(std::string program_string);
+        void TestFormula(std::string program_string) override;
 
-        virtual std::string GetKernel() const { return this->AssembleKernelSourceFromFormula(this->formula); }
+        std::string GetKernel() const override { return this->AssembleKernelSourceFromFormula(this->formula); }
 
-        virtual void SetFrom2DImage(int iChemical, vtkImageData *im);
+        void SetFrom2DImage(int iChemical, vtkImageData *im) override;
 
-        virtual void SetValue(float x,float y,float z,float val,const Properties& render_settings);
-        virtual void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings);
+        void SetValue(float x,float y,float z,float val,const Properties& render_settings) override;
+        void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings) override;
 
-        virtual void Undo();
-        virtual void Redo();
-        virtual void GetFromOpenCLBuffers( float* dest, int chemical_id );
+        void Undo() override;
+        void Redo() override;
+        void GetFromOpenCLBuffers(float* dest, int chemical_id) const;
 
     protected:
 
-        virtual void CopyFromImage(vtkImageData* im);
+        void CopyFromImage(vtkImageData* im) override;
 
-        virtual void AllocateImages(int x,int y,int z,int nc,int data_type);
+        void AllocateImages(int x,int y,int z,int nc,int data_type) override;
         void SetNumberOfChemicals(int n, bool reallocate_storage = false) override;
 
-        virtual void InternalUpdate(int n_steps);
+        void InternalUpdate(int n_steps) override;
 
-        virtual void ReloadKernelIfNeeded();
+        void ReloadKernelIfNeeded() override;
 
-        virtual void CreateOpenCLBuffers();
-        virtual void WriteToOpenCLBuffersIfNeeded();
-        virtual void ReadFromOpenCLBuffers();
+        void CreateOpenCLBuffers() override;
+        void WriteToOpenCLBuffersIfNeeded() override;
+        void ReadFromOpenCLBuffers() override;
 };
 
 #endif

--- a/src/readybase/OpenCLMeshRD.hpp
+++ b/src/readybase/OpenCLMeshRD.hpp
@@ -28,43 +28,43 @@ class OpenCLMeshRD : public MeshRD, public OpenCL_MixIn
     public:
 
         OpenCLMeshRD(int opencl_platform,int opencl_device,int data_type);
-        virtual ~OpenCLMeshRD();
+        ~OpenCLMeshRD();
 
         void SetNumberOfChemicals(int n, bool reallocate_storage = false) override;
 
-        virtual bool HasEditableFormula() const { return true; }
+        bool HasEditableFormula() const override { return true; }
 
-        virtual void CopyFromMesh(vtkUnstructuredGrid* mesh2);
+        void CopyFromMesh(vtkUnstructuredGrid* mesh2) override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel
-        virtual void AddParameter(const std::string& name,float val);
-        virtual void DeleteParameter(int iParam);
-        virtual void DeleteAllParameters();
-        virtual void SetParameterName(int iParam,const std::string& s);
-        virtual void SetParameterValue(int iParam,float val);
+        void AddParameter(const std::string& name,float val) override;
+        void DeleteParameter(int iParam) override;
+        void DeleteAllParameters() override;
+        void SetParameterName(int iParam,const std::string& s) override;
+        void SetParameterValue(int iParam,float val) override;
 
-        virtual void GenerateInitialPattern();
-        virtual void BlankImage(float value = 0.0f);
+        void GenerateInitialPattern() override;
+        void BlankImage(float value = 0.0f) override;
 
-        virtual void TestFormula(std::string program_string);
-        virtual std::string GetKernel() const { return this->AssembleKernelSourceFromFormula(this->formula); }
+        void TestFormula(std::string program_string) override;
+        std::string GetKernel() const override { return this->AssembleKernelSourceFromFormula(this->formula); }
 
-        virtual void SetValue(float x,float y,float z,float val,const Properties& render_settings);
-        virtual void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings);
+        void SetValue(float x,float y,float z,float val,const Properties& render_settings) override;
+        void SetValuesInRadius(float x,float y,float z,float r,float val,const Properties& render_settings) override;
 
-        virtual void Undo();
-        virtual void Redo();
+        void Undo() override;
+        void Redo() override;
 
     protected:
 
-        virtual void InternalUpdate(int n_steps);
+        void InternalUpdate(int n_steps) override;
 
-        virtual void ReloadKernelIfNeeded();
+        void ReloadKernelIfNeeded() override;
 
-        virtual void CreateOpenCLBuffers();
-        virtual void WriteToOpenCLBuffersIfNeeded();
-        virtual void ReadFromOpenCLBuffers();
-        virtual void ReleaseOpenCLBuffers();
+        void CreateOpenCLBuffers() override;
+        void WriteToOpenCLBuffersIfNeeded() override;
+        void ReadFromOpenCLBuffers() override;
+        void ReleaseOpenCLBuffers() override;
 
     private:
 

--- a/src/readybase/Properties.hpp
+++ b/src/readybase/Properties.hpp
@@ -29,7 +29,7 @@ class Property : public XML_Object
 {
     public:
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override;
         void ReadFromXML(vtkXMLDataElement* node);
 
         /// Construct as a float.
@@ -85,7 +85,7 @@ class Properties : public XML_Object
 
         Properties(std::string set_name) : XML_Object(NULL),set_name(set_name) {}
         void OverwriteFromXML(vtkXMLDataElement* node);
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override;
 
         int GetNumberOfProperties() const { return (int)this->properties.size(); }
         const Property& GetProperty(int i) const { return this->properties[i]; }

--- a/src/readybase/overlays.hpp
+++ b/src/readybase/overlays.hpp
@@ -39,13 +39,13 @@ class BaseShape;
 class Overlay : public XML_Object
 {
     public:
-    
+
         /// can construct from an XML node
         Overlay(vtkXMLDataElement* node);
         ~Overlay();
-            
+
         /// for saving to file, get the overlay as an XML element
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override;
 
         static const char* GetTypeName() { return "overlay"; }
 
@@ -55,7 +55,7 @@ class Overlay : public XML_Object
         double Apply(std::vector<double> vals,AbstractRD* system,float x,float y,float z) const;
 
     protected:
-    
+
         int iTargetChemical;             ///< each overlay applies to a single chemical
 
         BaseOperation *op;               ///< e.g. overwrite, add, multiply, etc.


### PR DESCRIPTION
 Removed unneeded virtual on overriding functions. This closes #96 