### PR TITLE
Refactored FormulaOpenCLImageRD::AssembleKernelSourceFromFormula()

### DIFF
--- a/src/readybase/AbstractRD.cpp
+++ b/src/readybase/AbstractRD.cpp
@@ -20,6 +20,7 @@
 #include "overlays.hpp"
 
 // STL:
+#include <algorithm>
 using namespace std;
 
 // SSE:

--- a/src/readybase/AbstractRD.cpp
+++ b/src/readybase/AbstractRD.cpp
@@ -98,23 +98,27 @@ int AbstractRD::GetNumberOfParameters() const
 
 std::string AbstractRD::GetParameterName(int iParam) const
 {
-    return this->parameters[iParam].first;
+    return this->parameters[iParam].name;
 }
 
 // ---------------------------------------------------------------------
 
 float AbstractRD::GetParameterValue(int iParam) const
 {
-    return this->parameters[iParam].second;
+    return this->parameters[iParam].value;
 }
 
 // ---------------------------------------------------------------------
 
 float AbstractRD::GetParameterValueByName(const std::string& name) const
 {
-    for(int iParam=0;iParam<(int)this->parameters.size();iParam++)
-        if(this->parameters[iParam].first == name)
-            return this->parameters[iParam].second;
+    for (const Parameter& parameter : this->parameters)
+    {
+        if (parameter.name == name)
+        {
+            return parameter.value;
+        }
+    }
     throw runtime_error("ImageRD::GetParameterValueByName : parameter name not found: "+name);
 }
 
@@ -122,7 +126,7 @@ float AbstractRD::GetParameterValueByName(const std::string& name) const
 
 void AbstractRD::AddParameter(const std::string& name,float val)
 {
-    this->parameters.push_back(make_pair(name,val));
+    this->parameters.push_back({ name, val });
     this->is_modified = true;
 }
 
@@ -146,7 +150,7 @@ void AbstractRD::DeleteAllParameters()
 
 void AbstractRD::SetParameterName(int iParam,const string& s)
 {
-    this->parameters[iParam].first = s;
+    this->parameters[iParam].name = s;
     this->is_modified = true;
 }
 
@@ -154,7 +158,7 @@ void AbstractRD::SetParameterName(int iParam,const string& s)
 
 void AbstractRD::SetParameterValue(int iParam,float val)
 {
-    this->parameters[iParam].second = val;
+    this->parameters[iParam].value = val;
     this->is_modified = true;
 }
 
@@ -162,10 +166,8 @@ void AbstractRD::SetParameterValue(int iParam,float val)
 
 bool AbstractRD::IsParameter(const string& name) const
 {
-    for(int i=0;i<(int)this->parameters.size();i++)
-        if(this->parameters[i].first == name)
-            return true;
-    return false;
+    return find_if(this->parameters.begin(), this->parameters.end(),
+        [&](const Parameter& param) { return param.name == name; }) != this->parameters.end();
 }
 
 // ---------------------------------------------------------------------

--- a/src/readybase/AbstractRD.hpp
+++ b/src/readybase/AbstractRD.hpp
@@ -173,6 +173,11 @@ class AbstractRD
         /// Returns the total memory size that will need to be transferred to the GPU
         virtual size_t GetMemorySize() const =0;
 
+        struct Parameter {
+            std::string name;
+            float value;
+        };
+
     protected: // typedefs
 
         enum TNeighborhood { VERTEX_NEIGHBORS, EDGE_NEIGHBORS, FACE_NEIGHBORS };
@@ -191,7 +196,7 @@ class AbstractRD
 
         InitialPatternGenerator initial_pattern_generator;
 
-        std::vector<std::pair<std::string,float> > parameters;
+        std::vector<Parameter> parameters;
 
         int timesteps_taken;
 

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -196,12 +196,6 @@ void AddKeywords(ostringstream& kernel_source, KeywordOptions& options)
     kernel_source << options.indent << "const int Y = get_global_size(1);\n";
     kernel_source << options.indent << "const int Z = get_global_size(2);\n";
     kernel_source << options.indent << "const int index_here = X*(Y*index_z + index_y) + index_x;\n";
-    /*for (int i = 0; i < NC; i++) TODO
-    {
-        kernel_source << indent << this->data_type_string << "4 " << GetChemicalName(i)
-            << " = " << GetChemicalName(i) << "_in[index_here];\n";
-        // (non-const, to allow the user to assign directly to it if wanted)
-    }*/
     // add the stencils we found
     AddStencils_Block411(kernel_source, options);
     // add x_pos, y_pos, z_pos if being used
@@ -282,6 +276,7 @@ string FormulaOpenCLImageRD::AssembleKernelSourceFromFormula(const string& formu
         kernel_source << indent << "const " << this->data_type_string << "4 " << this->parameters[i].first
                       << " = " << setprecision(8) << this->parameters[i].second << this->data_type_suffix << ";\n";
     // add a dx parameter for grid spacing if one is not already supplied
+    // TODO: only need this if using a stencil that includes it
     const bool has_dx_parameter = find_if(this->parameters.begin(), this->parameters.end(),
         [](const pair<string, float>& param) { return param.first == "dx"; }) != this->parameters.end();
     if (!options.stencils_needed.empty() && !has_dx_parameter)

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -152,7 +152,7 @@ struct KernelOptions {
 
 // -------------------------------------------------------------------------
 
-void AddCells(ostringstream& kernel_source, const set<InputPoint>& cells_needed, const KernelOptions& options)
+void WriteCellsNeeded(ostringstream& kernel_source, const set<InputPoint>& cells_needed, const KernelOptions& options)
 {
     // retrieve the float4 input blocks needed from global memory
     for (const InputPoint& input_point : cells_needed)
@@ -181,7 +181,7 @@ void AddCells(ostringstream& kernel_source, const set<InputPoint>& cells_needed,
 
 // -------------------------------------------------------------------------
 
-void AddKeywords(ostringstream& kernel_source, const InputsNeeded& inputs_needed, const KernelOptions& options)
+void WriteKeywords(ostringstream& kernel_source, const InputsNeeded& inputs_needed, const KernelOptions& options)
 {
     kernel_source << options.indent << "// keywords needed for the formula:\n";
     // output the first part of the body
@@ -193,7 +193,7 @@ void AddKeywords(ostringstream& kernel_source, const InputsNeeded& inputs_needed
     kernel_source << options.indent << "const int Z = get_global_size(2);\n";
     kernel_source << options.indent << "const int index_here = X*(Y*index_z + index_y) + index_x;\n";
     // add the the cells we need
-    AddCells(kernel_source, inputs_needed.cells_needed, options);
+    WriteCellsNeeded(kernel_source, inputs_needed.cells_needed, options);
     // add the stencils we need
     for (const AppliedStencil& applied_stencil : inputs_needed.stencils_needed)
     {
@@ -293,7 +293,7 @@ string WriteKernel(const InputsNeeded& inputs_needed,
     }
     kernel_source << "\n";
     // add the keywords we need
-    AddKeywords(kernel_source, inputs_needed, options);
+    WriteKeywords(kernel_source, inputs_needed, options);
     // add the formula
     kernel_source << options.indent << "// the formula:\n";
     istringstream iss(formula);

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -36,7 +36,7 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
 
         int GetBlockSizeX() const override { return 4; } // we use float4 in a 4x1x1 block
 
-        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
+        std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel
         void AddParameter(const std::string& name,float val) override;

--- a/src/readybase/FormulaOpenCLMeshRD.cpp
+++ b/src/readybase/FormulaOpenCLMeshRD.cpp
@@ -53,7 +53,8 @@ std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(const std::stri
 
     ostringstream kernel_source;
     kernel_source << fixed << setprecision(6);
-    if( this->data_type == VTK_DOUBLE ) {
+    if( this->data_type == VTK_DOUBLE )
+    {
         kernel_source << "\
 #ifdef cl_khr_fp64\n\
     #pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
@@ -91,8 +92,10 @@ std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(const std::stri
     kernel_source << "\n";
     // the parameters (assume all float for now)
     kernel_source << indent << "// parameters:\n";
-    for(int i=0;i<(int)this->parameters.size();i++)
-        kernel_source << indent << this->data_type_string << " " << this->parameters[i].first << " = " << this->parameters[i].second << this->data_type_suffix << ";\n";
+    for (const Parameter& parameter : this->parameters)
+    {
+        kernel_source << indent << this->data_type_string << " " << parameter.name << " = " << parameter.value << this->data_type_suffix << ";\n";
+    }
     // the update step
     for(int i=0;i<NC;i++)
         kernel_source << indent << this->data_type_string << " delta_" << GetChemicalName(i) << " = 0.0" << this->data_type_suffix << ";\n";

--- a/src/readybase/FormulaOpenCLMeshRD.cpp
+++ b/src/readybase/FormulaOpenCLMeshRD.cpp
@@ -46,7 +46,7 @@ delta_b = D_b * laplacian_b + a*b*b - (F+K)*b;");
 
 // -------------------------------------------------------------------------
 
-std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(std::string f) const
+std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(const std::string& f) const
 {
     const string indent = "    ";
     const int NC = this->GetNumberOfChemicals();
@@ -75,9 +75,11 @@ std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(std::string f) 
     kernel_source << indent << "const int index_x = get_global_id(0);\n";
     for(int i=0;i<NC;i++)
         kernel_source << indent << this->data_type_string << " " << GetChemicalName(i) << " = " << GetChemicalName(i) << "_in[index_x];\n";
+    kernel_source << "\n";
     // compute the laplacians
+    kernel_source << indent << "// compute the Laplacians\n";
     for(int i=0;i<NC;i++)
-        kernel_source << indent << this->data_type_string << " laplacian_" << GetChemicalName(i) << " = 0.0" << this->data_type_suffix << ";\n";
+        kernel_source << indent << this->data_type_string << " laplacian_" << GetChemicalName(i) << " = -" << GetChemicalName(i) << ";\n";
     kernel_source << indent << "int _offset = index_x * max_neighbors;\n";
     kernel_source << indent << "for(int _i=0;_i<max_neighbors;_i++)\n" << indent << "{\n";
     for(int i=0;i<NC;i++)
@@ -85,23 +87,24 @@ std::string FormulaOpenCLMeshRD::AssembleKernelSourceFromFormula(std::string f) 
                       << "_in[neighbor_indices[_offset+_i]] * neighbor_weights[_offset+_i];\n";
     kernel_source << indent << "}\n";
     for(int i=0;i<NC;i++)
-        kernel_source << indent << "laplacian_" << GetChemicalName(i) << " -= " << GetChemicalName(i) << ";\n";
-    kernel_source << indent << "// scale the Laplacians to be more similar to the 2D square grid version, so the same parameters work\n";
-    for(int i=0;i<NC;i++)
         kernel_source << indent << "laplacian_" << GetChemicalName(i) << " *= 4.0" << this->data_type_suffix << ";\n"; // TODO: not sure about 3D meshes
+    kernel_source << "\n";
     // the parameters (assume all float for now)
-    kernel_source << "\n" << indent << "// parameters:\n";
+    kernel_source << indent << "// parameters:\n";
     for(int i=0;i<(int)this->parameters.size();i++)
         kernel_source << indent << this->data_type_string << " " << this->parameters[i].first << " = " << this->parameters[i].second << this->data_type_suffix << ";\n";
     // the update step
-    kernel_source << "\n" << indent << "// update step:\n";
     for(int i=0;i<NC;i++)
         kernel_source << indent << this->data_type_string << " delta_" << GetChemicalName(i) << " = 0.0" << this->data_type_suffix << ";\n";
+    kernel_source << "\n" << indent << "// the formula:\n";
     kernel_source << f << "\n";
-    kernel_source << "\n";
+    // the forward-Euler step
+    kernel_source << indent << "// forward-Euler update step:\n";
     for(int i=0;i<NC;i++)
         kernel_source << indent << GetChemicalName(i) << "_out[index_x] = " << GetChemicalName(i) << " + timestep * delta_" << GetChemicalName(i) << ";\n";
+    // finish up
     kernel_source << "}\n";
+
     return kernel_source.str();
 }
 

--- a/src/readybase/FormulaOpenCLMeshRD.hpp
+++ b/src/readybase/FormulaOpenCLMeshRD.hpp
@@ -30,7 +30,7 @@ class FormulaOpenCLMeshRD : public OpenCLMeshRD
 
         std::string GetRuleType() const override { return "formula"; }
 
-        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
+        std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel
         void AddParameter(const std::string& name,float val) override;

--- a/src/readybase/FullKernelOpenCLImageRD.cpp
+++ b/src/readybase/FullKernelOpenCLImageRD.cpp
@@ -66,7 +66,7 @@ FullKernelOpenCLImageRD::FullKernelOpenCLImageRD(const OpenCLImageRD& source)
 
 // ---------------------------------------------------------------------------------------------------------
 
-string FullKernelOpenCLImageRD::AssembleKernelSourceFromFormula(std::string formula) const
+string FullKernelOpenCLImageRD::AssembleKernelSourceFromFormula(const string& formula) const
 {
     return formula; // here the formula is a full OpenCL kernel
 }

--- a/src/readybase/FullKernelOpenCLImageRD.hpp
+++ b/src/readybase/FullKernelOpenCLImageRD.hpp
@@ -41,7 +41,7 @@ class FullKernelOpenCLImageRD : public OpenCLImageRD
         void SetBlockSizeY(int n) override { this->block_size[1]=n; this->need_reload_formula=true; }
         void SetBlockSizeZ(int n) override { this->block_size[2]=n; this->need_reload_formula=true; }
 
-        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
+        std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         bool HasEditableDataType() const override { return false; }
 

--- a/src/readybase/FullKernelOpenCLMeshRD.cpp
+++ b/src/readybase/FullKernelOpenCLMeshRD.cpp
@@ -57,7 +57,7 @@ FullKernelOpenCLMeshRD::FullKernelOpenCLMeshRD(const OpenCLMeshRD& source)
 
 // ---------------------------------------------------------------------------------------------------------
 
-string FullKernelOpenCLMeshRD::AssembleKernelSourceFromFormula(std::string formula) const
+string FullKernelOpenCLMeshRD::AssembleKernelSourceFromFormula(const std::string& formula) const
 {
     return formula; // here the formula is a full OpenCL kernel
 }

--- a/src/readybase/FullKernelOpenCLMeshRD.hpp
+++ b/src/readybase/FullKernelOpenCLMeshRD.hpp
@@ -31,7 +31,7 @@ class FullKernelOpenCLMeshRD : public OpenCLMeshRD
 
         std::string GetRuleType() const override { return "kernel"; }
 
-        std::string AssembleKernelSourceFromFormula(std::string formula) const override;
+        std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         bool HasEditableDataType() const override { return false; }
 };

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -1239,7 +1239,7 @@ void ImageRD::SetNumberOfChemicals(int n, bool reallocate_storage)
     }
     if (n > this->n_chemicals)
     {
-        while (this->images.size() < n) {
+        while (static_cast<int>(this->images.size()) < n) {
             this->images.push_back( AllocateVTKImage(X, Y, Z, this->data_type) );
             this->images.back()->GetPointData()->GetScalars()->FillComponent(0, 0.0);
         }

--- a/src/readybase/OpenCL_MixIn.hpp
+++ b/src/readybase/OpenCL_MixIn.hpp
@@ -46,7 +46,7 @@ class OpenCL_MixIn
 
     protected:
 
-        virtual std::string AssembleKernelSourceFromFormula(std::string formula) const =0;
+        virtual std::string AssembleKernelSourceFromFormula(const std::string& formula) const =0;
 
         void ReloadContextIfNeeded();
         virtual void ReloadKernelIfNeeded() =0;

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -75,6 +75,10 @@ string InputPoint::GetName() const
 
 pair<InputPoint, InputPoint> InputPoint::GetAlignedBlocks() const
 {
+    if (point.x % 4 == 0)
+    {
+        throw runtime_error("internal error: already block-aligned in GetAlignedBlocks");
+    }
     // return the two block-aligned float4's we'll need to assemble this non-block-aligned float4
     InputPoint block_left{ point, chem };
     InputPoint block_right{ point, chem };

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -126,11 +126,19 @@ string InputPoint::GetDirectAccessCode(bool wrap) const
     {
         throw runtime_error("internal error in GetDirectAccessCode: point.x not divisible by 4");
     }
-    const string index_x = GetIndexString(point.x / 4, "x", "X", wrap);
-    const string index_y = GetIndexString(point.y, "y", "Y", wrap);
-    const string index_z = GetIndexString(point.z, "z", "Z", wrap);
     ostringstream oss;
-    oss << GetName() << " = " << chem << "_in[X * (Y * " << index_z << " + " << index_y << ") + " << index_x << "]";
+    oss << GetName() << " = " << chem << "_in[";
+    if (point.x == 0 && point.y == 0 && point.z == 0)
+    {
+        oss << "index_here";
+    }
+    else {
+        const string index_x = GetIndexString(point.x / 4, "x", "X", wrap);
+        const string index_y = GetIndexString(point.y, "y", "Y", wrap);
+        const string index_z = GetIndexString(point.z, "z", "Z", wrap);
+        oss << "X* (Y * " << index_z << " + " << index_y << ") + " << index_x;
+    }
+    oss << "]";
     return oss.str();
 }
 

--- a/src/readybase/utils.cpp
+++ b/src/readybase/utils.cpp
@@ -215,3 +215,12 @@ vector<string> tokenize_for_keywords(const string& formula)
 }
 
 // ---------------------------------------------------------------------------------------------------------
+
+bool UsingKeyword(const vector<string>& formula_tokens, const string& keyword)
+{
+    return find(formula_tokens.begin(), formula_tokens.end(), keyword) != formula_tokens.end();
+    // TODO: parse properly: ignore comments, not in string, etc.
+}
+
+// -------------------------------------------------------------------------
+

--- a/src/readybase/utils.hpp
+++ b/src/readybase/utils.hpp
@@ -89,6 +89,7 @@ void InterpolateInHSV(const float r1,const float g1,const float b1,const float r
 
 std::string ReplaceAllSubstrings(std::string subject, const std::string& search, const std::string& replace);
 std::vector<std::string> tokenize_for_keywords(const std::string& formula);
+bool UsingKeyword(const std::vector<std::string>& formula_tokens, const std::string& keyword);
 
 class ThrowOnErrorObserver : public vtkCommand
 {


### PR DESCRIPTION
Refactored `FormulaOpenCLImageRD::AssembleKernelSourceFromFormula()` into two stages:
1. Parsing the formula and collecting all the inputs needed: `DetectInputsNeeded()` returns an `InputsNeeded` (see below)
2. Writing the OpenCL code: `AssembleKernelSource()`.

```
struct InputsNeeded {
    vector<AppliedStencil> stencils_needed;
    set<InputPoint> cells_needed;
    map<string, int> gradient_mag_squared;
    bool using_x_pos;
    bool using_y_pos;
    bool using_z_pos;
    vector<string> deltas_needed;
};
```