### PR TITLE
Proposal: Expand the path and select the file in the Patterns pane when opening a file

### DIFF
--- a/src/gui/PatternsPanel.cpp
+++ b/src/gui/PatternsPanel.cpp
@@ -219,5 +219,5 @@ void PatternsPanel::SelectPath(const wxString& path)
     wxFileName full_path(path);
     full_path.MakeAbsolute();
     this->patternctrl->ExpandPath(full_path.GetFullPath());
-    this->patternctrl->SelectPath(full_path.GetFullPath());
+    this->patternctrl->SetPath(full_path.GetFullPath());
 }

--- a/src/gui/PatternsPanel.cpp
+++ b/src/gui/PatternsPanel.cpp
@@ -213,3 +213,11 @@ bool PatternsPanel::DoKey(int key, int mods)
     frame->ProcessKey(key, mods);
     return true;
 }
+
+void PatternsPanel::SelectPath(const wxString& path)
+{
+    wxFileName full_path(path);
+    full_path.MakeAbsolute();
+    this->patternctrl->ExpandPath(full_path.GetFullPath());
+    this->patternctrl->SelectPath(full_path.GetFullPath());
+}

--- a/src/gui/PatternsPanel.hpp
+++ b/src/gui/PatternsPanel.hpp
@@ -42,6 +42,8 @@ class PatternsPanel : public wxPanel
         // return false if key event should be passed to default handler
         bool DoKey(int key, int mods);
 
+        void SelectPath(const wxString& path);
+
     private:
 
         void AppendDir(const wxString& indir, wxTreeCtrl* treectrl, wxTreeItemId root);

--- a/src/gui/frame.cpp
+++ b/src/gui/frame.cpp
@@ -1657,6 +1657,7 @@ void MyFrame::OpenFile(const wxString& raw_path, bool remember)
     {
         SetDefaultRenderSettings(this->render_settings);
         target_system = SystemFactory::CreateFromFile(path.mb_str(),this->is_opencl_available,opencl_platform,opencl_device,this->render_settings,warn_to_update);
+        this->patterns_panel->SelectPath(path);
         this->SetCurrentRDSystem(move(target_system));
     }
     catch(const exception& e)


### PR DESCRIPTION
I think this is useful when first opening Ready, because otherwise it is not clear where the default pattern is (CPU-only/grayscott_3D.vti). 

And it seems to be helpful when clicking links in e.g. changes.html, for the same reason.

But it does leave more of the folders open and it's not strictly necessary. Thoughts?