### PR TITLE
New render setting: plot_ab_orthogonally. Allows us to draw 1D graphs as helices.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ set( PATTERN_FILES
   Patterns/RosenzweigMacArthur1963/hm_parameter_map.vti
   Patterns/RosenzweigMacArthur1963/predator-prey.vti
   Patterns/RosenzweigMacArthur1963/predator-prey_1D.vti
-  Patterns/LotkaVolterra1926/Lotka-Volterra.vti
+  Patterns/LotkaVolterra1926/Lotka-Volterra.vti      Patterns/LotkaVolterra1926/Lotka-Volterra_1D.vti
   Patterns/Kobayashi1993/crystal.vti                 Patterns/Kobayashi1993/crystals.vti
   Patterns/Kobayashi1993/laplacian_growth.vti
   Patterns/Kobayashi1993/laplacian_growth_3D.vti     Patterns/Kobayashi1993/laplacian_growth_3D_corner.vti

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ set( PATTERN_FILES
   Patterns/heat_equation_interpolation.vti
   Patterns/Ginzburg-Landau/complex_Ginzburg-Landau.vti
   Patterns/Ginzburg-Landau/complex_Ginzburg-Landau_magnitude.vti
-  Patterns/wave_equation.vti
+  Patterns/wave_equation.vti               Patterns/wave_soliton.vti
   Patterns/oregonator.vti
   Patterns/Brusselator.vti
   Patterns/SmoothLife2011/smoothglider.vti     Patterns/SmoothLife2011/smoothlifeL.vti     Patterns/SmoothLife2011/glider_3D.vti

--- a/Help/changes.html
+++ b/Help/changes.html
@@ -25,7 +25,7 @@ the neighbor of the current block, these keywords return a float4 that has the f
 stencils. Formula rules no longer need to write e.g. laplacian_a / (delta_x * delta_x) and can just write laplacian_a since the value of dx is used in the stencil computation.
 <li>New <a href="formats.html#render_settings">render setting</a>: <b>colormap</b>, with 11 maps available: "HSV blend", "spectral", "spectral reversed", "inferno", "inferno reversed", "terrain", "terrain reversed", "orange-purple", "purple-orange", "brown-teal", "teal-brown". The old behavior (HSV interpolation between two colors) is still available - choose "HSV blend".
 <li>New <a href="formats.html#render_settings">render setting</a>: <b>plot_ab_orthogonally</b>. If true in a 1d pattern, we
-plot chemicals 'a' and 'b' against each other in the line graph, allowing us to show e.g. <a href="open:Patterns/Schrodinger1926/packet.vti">Schrodinger equation wave packets</a> as a corkscrew.
+plot chemicals 'a' and 'b' against each other in the line graph, allowing us to show e.g. <a href="open:Patterns/Schrodinger1926/packet.vti">Schrodinger1926/packet.vti</a> or <a href="open:Patterns/Yang2006/jumping_cGL.vti">Yang2006/jumping_cGL.vti</a> in a more useful way.
 <li>Moved View Full Kernel... and Show OpenCL Diagnostics... to the View menu.
 <li>Mac app requires macOS 10.10 or later.
 <li>More smaller brush sizes.

--- a/Help/changes.html
+++ b/Help/changes.html
@@ -35,6 +35,7 @@ stencils. Formula rules no longer need to write e.g. laplacian_a / (delta_x * de
     <li>In Experiments/TihaVonGhyczy: <a href="open:Patterns/Experiments/TihaVonGhyczy/sobel_waves.vti">sobel_waves.vti</a>.
     <li>In Experiments/TimHutton: <a href="open:Patterns/Experiments/TimHutton/mutually-catalytic_spots_2.vti">mutually-catalytic_spots_2.vti</a>.
     <li><a href="open:Patterns/wave_soliton.vti">wave_soliton.vti</a>
+    <li><a href="open:Patterns/LotkaVolterra1926/Lotka-Volterra_1D.vti">LotkaVolterra1926/Lotka-Volterra_1D.vti</a>
   </ul>
 </ul>
 

--- a/Help/changes.html
+++ b/Help/changes.html
@@ -24,6 +24,8 @@ the neighbor of the current block, these keywords return a float4 that has the f
 <li>Parameter <b>dx</b> is now reserved for controlling the grid spacing of the Gaussian, Laplacian, bi-Laplacian and tri-Laplacian
 stencils. Formula rules no longer need to write e.g. laplacian_a / (delta_x * delta_x) and can just write laplacian_a since the value of dx is used in the stencil computation.
 <li>New <a href="formats.html#render_settings">render setting</a>: <b>colormap</b>, with 11 maps available: "HSV blend", "spectral", "spectral reversed", "inferno", "inferno reversed", "terrain", "terrain reversed", "orange-purple", "purple-orange", "brown-teal", "teal-brown". The old behavior (HSV interpolation between two colors) is still available - choose "HSV blend".
+<li>New <a href="formats.html#render_settings">render setting</a>: <b>plot_ab_orthogonally</b>. If true in a 1d pattern, we
+plot chemicals 'a' and 'b' against each other in the line graph, allowing us to show e.g. <a href="open:Patterns/Schrodinger1926/packet.vti">Schrodinger equation wave packets</a> as a corkscrew.
 <li>Moved View Full Kernel... and Show OpenCL Diagnostics... to the View menu.
 <li>Mac app requires macOS 10.10 or later.
 <li>More smaller brush sizes.

--- a/Help/changes.html
+++ b/Help/changes.html
@@ -34,6 +34,7 @@ stencils. Formula rules no longer need to write e.g. laplacian_a / (delta_x * de
     <li><a href="open:Patterns/Kobayashi1993/crystals.vti">Kobayashi1993/crystals.vti</a>
     <li>In Experiments/TihaVonGhyczy: <a href="open:Patterns/Experiments/TihaVonGhyczy/sobel_waves.vti">sobel_waves.vti</a>.
     <li>In Experiments/TimHutton: <a href="open:Patterns/Experiments/TimHutton/mutually-catalytic_spots_2.vti">mutually-catalytic_spots_2.vti</a>.
+    <li><a href="open:Patterns/wave_soliton.vti">wave_soliton.vti</a>
   </ul>
 </ul>
 

--- a/Help/formats.html
+++ b/Help/formats.html
@@ -482,6 +482,8 @@ chemicals for each pixel plotted against each other).
 <li><tt>&lt;phase_plot_x value="a" /&gt;</tt><br>The chemical to show on the horizontal plot axis (a, b, c, etc.).
 <li><tt>&lt;phase_plot_y value="b" /&gt;</tt><br>The chemical to show on the vertical plot axis (a, b, c, etc.).
 <li><tt>&lt;phase_plot_z value="c" /&gt;</tt><br>The chemical to show on the inwards plot axis (a, b, c, etc.).
+<li><tt>&lt;plot_ab_orthogonally value="false" /&gt;</tt><br>If true in a 1D pattern, we plot a and b against each other
+in the line graph, allowing us to show e.g. <a href="open:Patterns/Schrodinger1926/packet.vti">Schrodinger equation wave packets</a> as a corkscrew.
 </ul>
 
 </body>

--- a/Help/formats.html
+++ b/Help/formats.html
@@ -286,7 +286,7 @@ Each overlay changes the values of a single chemical. Overlays apply in the orde
 <tt><a href="#subtract">subtract</a></tt>, <tt><a href="#multiply">multiply</a></tt> or <tt><a href="#divide">divide</a></tt>.
 <li>fill (required) : one of <tt><a href="#constant">constant</a></tt>, <tt><a href="#white_noise">white_noise</a></tt>,
 <tt><a href="#other_chemical">other_chemical</a></tt>, <tt><a href="#linear_gradient">linear_gradient</a></tt>,
-<tt><a href="#radial_gradient">radial_gradient</a></tt>, <tt></tt><a href="#gaussian">gaussian</a></tt>,
+<tt><a href="#radial_gradient">radial_gradient</a></tt>, <tt><a href="#gaussian">gaussian</a></tt>,
 <tt><a href="#sine">sine</a></tt> or <tt><a href="#parameter">parameter</a></tt>.
 <li>shape (required) : one or more of <tt><a href="#everywhere">everywhere</a></tt>, <tt><a href="#rectangle">rectangle</a></tt>,
 <tt><a href="#circle">circle</a></tt> or <tt><a href="#pixel">pixel</a></tt>. Any cell with a centroid inside the shape will be affected.

--- a/Patterns/LotkaVolterra1926/Lotka-Volterra_1D.vti
+++ b/Patterns/LotkaVolterra1926/Lotka-Volterra_1D.vti
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
+  <RD format_version="6">
+    <description>
+      Lotka-Volterra with diffusion.
+      &lt;a href=&quot;http://en.wikipedia.org/wiki/Lotka-Volterra_equations&quot;&gt;http://en.wikipedia.org/wiki/Lotka-Volterra_equations&lt;/a&gt;
+
+      A model of predator-prey cycles. Here &apos;a&apos; is the concentration of the prey at each location and &apos;b&apos; the predator.
+
+      In this pattern we are plotting &apos;a&apos; and &apos;b&apos; orthogonally to each other - you might need to
+      rotate the scene to view the graph from the side.  Set &apos;plot ab orthogonally&apos; to false to plot them
+      separately.
+    </description>
+    <rule name="Lotka-Volterra" type="formula" wrap="0" neighborhood_type="vertex">
+      <param name="timestep">
+        0.050000
+      </param>
+      <param name="D_a">
+        1.000000
+      </param>
+      <param name="D_b">
+        1.000000
+      </param>
+      <param name="alpha">
+        1.000000
+      </param>
+      <param name="beta">
+        1.000000
+      </param>
+      <param name="gamma">
+        1.000000
+      </param>
+      <param name="delta">
+        1.000000
+      </param>
+      <formula number_of_chemicals="2">
+        delta_a = D_a * laplacian_a + alpha * a - beta * a * b;
+        delta_b = D_b * laplacian_b + delta * a * b - gamma * b;
+
+      </formula>
+    </rule>
+    <initial_pattern_generator apply_when_loading="true" zero_first="false">
+      <overlay chemical="a">
+        <overwrite/>
+        <white_noise low="0" high="0.5"/>
+        <everywhere/>
+      </overlay>
+      <overlay chemical="b">
+        <overwrite/>
+        <white_noise low="0" high="0.5"/>
+        <everywhere/>
+      </overlay>
+    </initial_pattern_generator>
+    <render_settings>
+      <surface_color r="1" g="1" b="1"/>
+      <colormap value="spectral"/>
+      <color_low r="0" g="0" b="1"/>
+      <color_high r="1" g="0" b="0"/>
+      <show_color_scale value="true"/>
+      <show_multiple_chemicals value="true"/>
+      <active_chemical value="b"/>
+      <low value="0"/>
+      <high value="3"/>
+      <vertical_scale_1D value="30"/>
+      <vertical_scale_2D value="15"/>
+      <contour_level value="0.25"/>
+      <cap_contour value="true"/>
+      <invert_contour_cap value="false"/>
+      <use_wireframe value="false"/>
+      <show_cell_edges value="false"/>
+      <show_bounding_box value="true"/>
+      <show_chemical_label value="true"/>
+      <slice_3D value="true"/>
+      <slice_3D_axis value="z"/>
+      <slice_3D_position value="0.5"/>
+      <show_displacement_mapped_surface value="false"/>
+      <color_displacement_mapped_surface value="false"/>
+      <use_image_interpolation value="true"/>
+      <timesteps_per_render value="4"/>
+      <show_phase_plot value="true"/>
+      <phase_plot_x_axis value="a"/>
+      <phase_plot_y_axis value="b"/>
+      <phase_plot_z_axis value="c"/>
+      <plot_ab_orthogonally value="true"/>
+    </render_settings>
+  </RD>
+  <ImageData WholeExtent="0 255 0 0 0 0" Origin="0 0 0" Spacing="1 1 1" Direction="1 0 0 0 1 0 0 0 1">
+  <Piece Extent="0 255 0 0 0 0">
+    <PointData>
+      <DataArray type="Float32" Name="a" format="binary" RangeMin="0" RangeMax="0">
+        AQAAAACAAAAABAAAEQAAAA==eJxjYBgFo2AUjFQAAAQAAAE=
+      </DataArray>
+      <DataArray type="Float32" Name="b" format="binary" RangeMin="0" RangeMax="0">
+        AQAAAACAAAAABAAAEQAAAA==eJxjYBgFo2AUjFQAAAQAAAE=
+      </DataArray>
+    </PointData>
+    <CellData>
+    </CellData>
+  </Piece>
+  </ImageData>
+</VTKFile>

--- a/Patterns/Schrodinger1926/packet.vti
+++ b/Patterns/Schrodinger1926/packet.vti
@@ -1,51 +1,42 @@
 <?xml version="1.0"?>
 <VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <RD format_version="4">
+  <RD format_version="6">
 
     <description>
-        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the 
-        wave function for some quantum state. Here a wave packet travels through empty space. Over time the probability spreads out, because of
+        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the
+        wave function for some quantum state. Here a wave packet travels through empty space. Over time the wave packet spreads out, because of
         uncertainty in its initial momentum.
-        
-        In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part. 
-        The probability density is shown in 'c'.
-        
+
+        In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part.
+
         Derivation:
-        
+
         &lt;tt&gt;
         i*(dx/dt) = -Laplacian(x)
         &lt;/tt&gt;
-        
+
         where x is a complex number a+bi, i is the square root of -1.
-        
+
         hence:
         &lt;tt&gt;&lt;pre&gt;da/dt = -Im(Laplacian(x)) = -Laplacian(b)
         db/dt =  Re(Laplacian(x)) =  Laplacian(a)&lt;/pre&gt;&lt;/tt&gt;
-        
-        c = a&lt;sup&gt;2&lt;/sup&gt; + b&lt;sup&gt;2&lt;/sup&gt;
-    </description>
+
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
+        below to false to plot them as separate lines on the graph.
+      </description>
 
     <rule type="formula" name="Schrodinger equation">
-        
+
       <param name="timestep">    0.001    </param>
 
-      <formula number_of_chemicals="3">
+      <formula number_of_chemicals="2">
         delta_a = -laplacian_b;
         delta_b =  laplacian_a;
-        c = a*a + b*b;
       </formula>
-      
+
     </rule>
-    
+
     <initial_pattern_generator apply_when_loading="true">
-        
-      <overlay chemical="c">
-        <overwrite />
-        <gaussian height="1" sigma="0.03">
-          <point3D x="0.2" y="0.3" z="0.5" />
-        </gaussian>
-        <everywhere />
-      </overlay>
 
       <overlay chemical="a">
         <overwrite />
@@ -55,8 +46,14 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="a"><multiply /><other_chemical chemical="c" /><everywhere /></overlay>
-      
+      <overlay chemical="a">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.3" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
+
       <overlay chemical="b">
         <overwrite />
         <sine amplitude="1" phase="1.5708">
@@ -65,14 +62,19 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="b"><multiply /><other_chemical chemical="c" /><everywhere /></overlay>
-
-      <overlay chemical="c"><multiply /><other_chemical chemical="c" /><everywhere /></overlay>
+      <overlay chemical="b">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.3" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
 
     </initial_pattern_generator>
-    
+
     <render_settings>
-       <active_chemical value="c" />
+       <active_chemical value="a" />
+       <show_multiple_chemicals value="true" />
        <show_displacement_mapped_surface value="true" />
        <color_displacement_mapped_surface value="false" />
        <low value="-1" />
@@ -80,8 +82,9 @@
        <vertical_scale_1D value="100" />
        <vertical_scale_2D value="100" />
        <timesteps_per_render value="1024" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
-    
+
   </RD>
   <ImageData WholeExtent="0 511 0 0 0 0" Origin="0 0 0" Spacing="1 1 1">
   <Piece Extent="0 511 0 0 0 0">
@@ -90,9 +93,6 @@
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
       <DataArray type="Float32" Name="b" format="binary" RangeMin="0" RangeMax="0">
-        AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
-      </DataArray>
-      <DataArray type="Float32" Name="c" format="binary" RangeMin="0" RangeMax="0">
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
     </PointData>

--- a/Patterns/Schrodinger1926/packet.vti
+++ b/Patterns/Schrodinger1926/packet.vti
@@ -21,8 +21,9 @@
         &lt;tt&gt;&lt;pre&gt;da/dt = -Im(Laplacian(x)) = -Laplacian(b)
         db/dt =  Re(Laplacian(x)) =  Laplacian(a)&lt;/pre&gt;&lt;/tt&gt;
 
-        By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
-        below to false to plot them as separate lines on the graph.
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation - you might need to rotate
+        the scene to view the graph from the side. Set 'plot ab orthogonally' below to false to plot 'a' and 'b' as
+        separate lines on the graph.
       </description>
 
     <rule type="formula" name="Schrodinger equation">

--- a/Patterns/Schrodinger1926/packet.vti
+++ b/Patterns/Schrodinger1926/packet.vti
@@ -24,6 +24,8 @@
         By default we plot 'a' and 'b' on orthogonal axes to show the rotation - you might need to rotate
         the scene to view the graph from the side. Set 'plot ab orthogonally' below to false to plot 'a' and 'b' as
         separate lines on the graph.
+
+        Instabilities appear after around 1.4M steps, because we are only using simple numerical methods.
       </description>
 
     <rule type="formula" name="Schrodinger equation">

--- a/Patterns/Schrodinger1926/packet_pass.vti
+++ b/Patterns/Schrodinger1926/packet_pass.vti
@@ -14,6 +14,8 @@
 
         By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
         below to false to plot them as separate lines on the graph.
+
+        Instabilities appear after around 1.4M steps, because we are only using simple numerical methods.
     </description>
 
     <rule type="formula" name="Schrodinger equation" wrap="0">

--- a/Patterns/Schrodinger1926/packet_pass.vti
+++ b/Patterns/Schrodinger1926/packet_pass.vti
@@ -1,41 +1,34 @@
 <?xml version="1.0"?>
 <VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <RD format_version="4">
-    
+  <RD format_version="6">
+
     <description>
-        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the 
+        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the
         wave function for some quantum state. Here a wave packet travels through empty space until it reaches a low energy barrier, which it is able to
         pass over.
-        
+
         In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part. A fixed energy background is given by 'c'.
-        The probability density is shown in 'd'.
-        
+
         By changing the values of parameter 'potential' and then using 'Generate Initial Pattern' from the 'Action' menu you can change the height
         of the barrier. Or you can paint directly into 'c'.
+
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
+        below to false to plot them as separate lines on the graph.
     </description>
 
     <rule type="formula" name="Schrodinger equation" wrap="0">
-        
+
       <param name="timestep">    0.001    </param>
       <param name="potential">   0.1      </param>
 
-      <formula number_of_chemicals="4">
+      <formula number_of_chemicals="3">
         delta_a = -laplacian_b - c*b;
         delta_b =  laplacian_a + c*a;
-        d = a*a + b*b;
       </formula>
-      
+
     </rule>
-    
+
     <initial_pattern_generator apply_when_loading="true">
-        
-      <overlay chemical="d">
-        <overwrite />
-        <gaussian height="1" sigma="0.03">
-          <point3D x="0.2" y="0.5" z="0.5" />
-        </gaussian>
-        <everywhere />
-      </overlay>
 
       <overlay chemical="a">
         <overwrite />
@@ -45,8 +38,14 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="a"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+      <overlay chemical="a">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.5" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
+
       <overlay chemical="b">
         <overwrite />
         <sine amplitude="1" phase="1.5708">
@@ -55,8 +54,14 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="b"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+      <overlay chemical="b">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.5" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
+
       <overlay chemical="c">
         <overwrite />
         <parameter name="potential" />
@@ -65,13 +70,11 @@
           <point3d x="0.45" y="0.6" z="0.6" />
         </rectangle>
       </overlay>
-      
-      <overlay chemical="d"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
 
     </initial_pattern_generator>
-    
+
     <render_settings>
-       <active_chemical value="d" />
+       <active_chemical value="a" />
        <show_displacement_mapped_surface value="true" />
        <color_displacement_mapped_surface value="false" />
        <low value="-1" />
@@ -79,8 +82,9 @@
        <vertical_scale_1D value="100" />
        <vertical_scale_2D value="100" />
        <timesteps_per_render value="1024" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
-    
+
   </RD>
   <ImageData WholeExtent="0 511 0 0 0 0" Origin="0 0 0" Spacing="1 1 1">
   <Piece Extent="0 511 0 0 0 0">
@@ -92,9 +96,6 @@
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
       <DataArray type="Float32" Name="c" format="binary" RangeMin="0" RangeMax="0">
-        AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
-      </DataArray>
-      <DataArray type="Float32" Name="d" format="binary" RangeMin="0" RangeMax="0">
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
     </PointData>

--- a/Patterns/Schrodinger1926/packet_reflect.vti
+++ b/Patterns/Schrodinger1926/packet_reflect.vti
@@ -14,6 +14,8 @@
 
         By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
         below to false to plot them as separate lines on the graph.
+
+        Instabilities appear after around 1.4M steps, because we are only using simple numerical methods.
     </description>
 
     <rule type="formula" name="Schrodinger equation">

--- a/Patterns/Schrodinger1926/packet_reflect.vti
+++ b/Patterns/Schrodinger1926/packet_reflect.vti
@@ -1,20 +1,23 @@
 <?xml version="1.0"?>
 <VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <RD format_version="4">
+  <RD format_version="6">
 
     <description>
-        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the 
+        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the
         wave function for some quantum state. Here a wave packet travels through empty space until it reaches a high energy barrier, which it is reflected from.
-        
+
         In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part. A fixed energy background is given by 'c'.
         The probability density is shown in 'd'.
-        
+
         By changing the values of parameter 'potential' and then using 'Generate Initial Pattern' from the 'Action' menu you can change the height
         of the barrier. Or you can paint directly into 'c'.
+
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
+        below to false to plot them as separate lines on the graph.
     </description>
 
     <rule type="formula" name="Schrodinger equation">
-        
+
       <param name="timestep">    0.001    </param>
       <param name="potential">   4        </param>
 
@@ -23,11 +26,11 @@
         delta_b =  laplacian_a + c*a;
         d = a*a + b*b;
       </formula>
-      
+
     </rule>
-    
+
     <initial_pattern_generator apply_when_loading="true">
-        
+
       <overlay chemical="d">
         <overwrite />
         <gaussian height="1" sigma="0.03">
@@ -45,7 +48,7 @@
         <everywhere />
       </overlay>
       <overlay chemical="a"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
       <overlay chemical="b">
         <overwrite />
         <sine amplitude="1" phase="1.5708">
@@ -55,7 +58,7 @@
         <everywhere />
       </overlay>
       <overlay chemical="b"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
       <overlay chemical="c">
         <overwrite />
         <parameter name="potential" />
@@ -66,9 +69,9 @@
       </overlay>
 
       <overlay chemical="d"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
     </initial_pattern_generator>
-    
+
     <render_settings>
        <active_chemical value="d" />
        <show_displacement_mapped_surface value="true" />
@@ -78,8 +81,9 @@
        <vertical_scale_1D value="100" />
        <vertical_scale_2D value="100" />
        <timesteps_per_render value="1024" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
-    
+
   </RD>
   <ImageData WholeExtent="0 511 0 0 0 0" Origin="0 0 0" Spacing="1 1 1">
   <Piece Extent="0 511 0 0 0 0">

--- a/Patterns/Schrodinger1926/packet_reflect2D.vti
+++ b/Patterns/Schrodinger1926/packet_reflect2D.vti
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <RD format_version="4">
+  <RD format_version="6">
 
     <description>
-        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the 
+        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the
         wave function for some quantum state. Here a wave packet travels through empty space until it reaches a high energy barrier, which it is reflected from.
-        
+
         In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part. A fixed energy background is given by 'c'.
         The probability density is shown in 'd', with the barrier overlaid.
-        
+
         By changing the values of parameter 'potential' and then using 'Generate Initial Pattern' from the 'Action' menu you can change the height
         of the barrier. Or you can paint directly into 'c'.
     </description>
 
     <rule type="formula" name="Schrodinger equation">
-        
+
       <param name="timestep">    0.001    </param>
       <param name="potential">   4        </param>
 
@@ -23,11 +23,11 @@
         delta_b =  laplacian_a + c*a;
         d = a*a + b*b + c;
       </formula>
-      
+
     </rule>
-    
+
     <initial_pattern_generator apply_when_loading="true">
-        
+
       <overlay chemical="d">
         <overwrite />
         <gaussian height="1" sigma="0.05">
@@ -45,7 +45,7 @@
         <everywhere />
       </overlay>
       <overlay chemical="a"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
       <overlay chemical="b">
         <overwrite />
         <sine amplitude="1" phase="1.5708">
@@ -55,7 +55,7 @@
         <everywhere />
       </overlay>
       <overlay chemical="b"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
       <overlay chemical="c">
         <overwrite />
         <parameter name="potential" />
@@ -64,17 +64,17 @@
           <point3d x="0.5" y="0.8" z="0.8" />
         </rectangle>
       </overlay>
-            
+
       <overlay chemical="d"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
 
       <overlay chemical="d">
         <add />
         <other_chemical chemical="c" />
         <everywhere />
-      </overlay>            
+      </overlay>
 
     </initial_pattern_generator>
-    
+
     <render_settings>
        <active_chemical value="d" />
        <show_displacement_mapped_surface value="true" />
@@ -85,8 +85,9 @@
        <vertical_scale_2D value="50" />
        <timesteps_per_render value="256" />
        <show_phase_plot value="false" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
-    
+
   </RD>
   <ImageData WholeExtent="0 127 0 127 0 0" Origin="0 0 0" Spacing="1 1 1">
   <Piece Extent="0 127 0 127 0 0">

--- a/Patterns/Schrodinger1926/quantum_tunnelling.vti
+++ b/Patterns/Schrodinger1926/quantum_tunnelling.vti
@@ -1,41 +1,34 @@
 <?xml version="1.0"?>
 <VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
-  <RD format_version="4">
+  <RD format_version="6">
 
     <description>
-        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the 
+        The &lt;a href=&quot;http://en.wikipedia.org/wiki/Schr%C3%B6dinger_equation&quot;&gt;Schrödinger equation&lt;/a&gt; describes the change in the
         wave function for some quantum state. Here a wave packet travels through empty space until it reaches an energy barrier. Despite having less energy than the barrier, there is a non-zero
         probability of the particle passing through, due to 'quantum tunnelling'.
-        
+
         In our implementation, 'a' represents the real part of the complex number and 'b' the imaginary part. A fixed energy background is given by 'c'.
-        The probability density is shown in 'd'.
-        
+
         By changing the values of parameter 'potential' and then using 'Generate Initial Pattern' from the 'Action' menu you can change the height
         of the barrier. Or you can paint directly into 'c'.
+
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
+        below to false to plot them as separate lines on the graph.
     </description>
 
     <rule type="formula" name="Schrodinger equation" wrap="0">
-        
+
       <param name="timestep">    0.001    </param>
       <param name="potential">   3        </param>
 
-      <formula number_of_chemicals="4">
+      <formula number_of_chemicals="3">
         delta_a = -laplacian_b - c*b;
         delta_b =  laplacian_a + c*a;
-        d = a*a + b*b;
       </formula>
-      
+
     </rule>
-    
+
     <initial_pattern_generator apply_when_loading="true">
-        
-      <overlay chemical="d">
-        <overwrite />
-        <gaussian height="1" sigma="0.03">
-          <point3D x="0.2" y="0.5" z="0.5" />
-        </gaussian>
-        <everywhere />
-      </overlay>
 
       <overlay chemical="a">
         <overwrite />
@@ -45,8 +38,14 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="a"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+      <overlay chemical="a">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.5" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
+
       <overlay chemical="b">
         <overwrite />
         <sine amplitude="1" phase="1.5708">
@@ -55,8 +54,14 @@
         </sine>
         <everywhere />
       </overlay>
-      <overlay chemical="b"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+      <overlay chemical="b">
+        <multiply />
+        <gaussian height="1" sigma="0.03">
+          <point3D x="0.2" y="0.5" z="0.5" />
+        </gaussian>
+        <everywhere />
+      </overlay>
+
       <overlay chemical="c">
         <overwrite />
         <parameter name="potential" />
@@ -65,13 +70,11 @@
           <point3d x="0.45" y="0.6" z="0.6" />
         </rectangle>
       </overlay>
-      
-      <overlay chemical="d"><multiply /><other_chemical chemical="d" /><everywhere /></overlay>
-      
+
     </initial_pattern_generator>
-    
+
     <render_settings>
-       <active_chemical value="d" />
+       <active_chemical value="a" />
        <show_displacement_mapped_surface value="true" />
        <color_displacement_mapped_surface value="false" />
        <low value="-1" />
@@ -79,8 +82,9 @@
        <vertical_scale_1D value="100" />
        <vertical_scale_2D value="100" />
        <timesteps_per_render value="1024" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
-    
+
   </RD>
   <ImageData WholeExtent="0 511 0 0 0 0" Origin="0 0 0" Spacing="1 1 1">
   <Piece Extent="0 511 0 0 0 0">
@@ -92,9 +96,6 @@
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
       <DataArray type="Float32" Name="c" format="binary" RangeMin="0" RangeMax="0">
-        AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
-      </DataArray>
-      <DataArray type="Float32" Name="d" format="binary" RangeMin="0" RangeMax="0">
         AQAAAACAAAAACAAAFwAAAA==eJxjYBgFo2AUjIJRMApGwUgDAAgAAAE=
       </DataArray>
     </PointData>

--- a/Patterns/Schrodinger1926/quantum_tunnelling.vti
+++ b/Patterns/Schrodinger1926/quantum_tunnelling.vti
@@ -14,6 +14,8 @@
 
         By default we plot 'a' and 'b' on orthogonal axes to show the rotation. Set 'plot ab orthogonally'
         below to false to plot them as separate lines on the graph.
+
+        Instabilities appear after around 1.4M steps, because we are only using simple numerical methods.
     </description>
 
     <rule type="formula" name="Schrodinger equation" wrap="0">

--- a/Patterns/Schrodinger1926/two_slit.vti
+++ b/Patterns/Schrodinger1926/two_slit.vti
@@ -97,6 +97,7 @@
        <show_phase_plot value="false" />
        <contour_level value="0.01" />
        <slice_3D value="false" />
+       <plot_ab_orthogonally value="true" />
     </render_settings>
 
   </RD>

--- a/Patterns/Yang2006/jumping_cGL.vti
+++ b/Patterns/Yang2006/jumping_cGL.vti
@@ -20,6 +20,9 @@
 
         Note that parameter nu is different to that shown in the paper. Another anomaly is that
         the 'narrow oscillon' mentioned doesn't seem to be present.
+
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation of the oscillons. Set 'plot ab orthogonally'
+        below to false to plot them as separate lines on the graph.
     </description>
 
     <rule type="formula" name="Ginzburg-Landau">
@@ -102,6 +105,7 @@
       <vertical_scale_1D value="100" />
       <contour_level value="0" />
       <show_color_scale value="false" />
+      <plot_ab_orthogonally value="true" />
     </render_settings>
 
   </RD>

--- a/Patterns/Yang2006/jumping_cGL.vti
+++ b/Patterns/Yang2006/jumping_cGL.vti
@@ -22,7 +22,7 @@
         the 'narrow oscillon' mentioned doesn't seem to be present.
 
         By default we plot 'a' and 'b' on orthogonal axes to show the rotation of the oscillons - you might need to rotate
-        the scene to view the graph from the side. Compare with the wave packets in the &lt;a href=&quot;open:Patterns/Schrodinger1926/packet.vti&quot;&gt;Schrödinger equation&lt;/a&gt;. Set 'plot ab orthogonally'
+        the scene to view the graph from the side. The oscillons are revealed to be pure rotation. Compare with the wave packets in the &lt;a href=&quot;open:Patterns/Schrodinger1926/packet.vti&quot;&gt;Schrödinger equation&lt;/a&gt;. Set 'plot ab orthogonally'
         below to false to plot 'a' and 'b' as separate lines on the graph.
     </description>
 

--- a/Patterns/Yang2006/jumping_cGL.vti
+++ b/Patterns/Yang2006/jumping_cGL.vti
@@ -21,8 +21,9 @@
         Note that parameter nu is different to that shown in the paper. Another anomaly is that
         the 'narrow oscillon' mentioned doesn't seem to be present.
 
-        By default we plot 'a' and 'b' on orthogonal axes to show the rotation of the oscillons. Set 'plot ab orthogonally'
-        below to false to plot them as separate lines on the graph.
+        By default we plot 'a' and 'b' on orthogonal axes to show the rotation of the oscillons - you might need to rotate
+        the scene to view the graph from the side. Compare with the wave packets in the &lt;a href=&quot;open:Patterns/Schrodinger1926/packet.vti&quot;&gt;Schrödinger equation&lt;/a&gt;. Set 'plot ab orthogonally'
+        below to false to plot 'a' and 'b' as separate lines on the graph.
     </description>
 
     <rule type="formula" name="Ginzburg-Landau">

--- a/Patterns/wave_equation.vti
+++ b/Patterns/wave_equation.vti
@@ -18,7 +18,7 @@
 
         d^2a/dt^2 = db/dt = laplacian_a
 
-        To avoid a time delay in updating 'a' we first update b fully, using our standard forward-Euler integration:
+        To avoid a time delay in updating 'a' we first update 'b' fully, using our standard forward-Euler integration:
 
         b += laplacian_a * timestep
 

--- a/Patterns/wave_soliton.vti
+++ b/Patterns/wave_soliton.vti
@@ -8,7 +8,7 @@
       d^2a/dt^2 = laplacian_a
 
       This pattern has been initialized with a soliton - a pulse that moves along without spreading out. Compare with the
-      &lt;a href&quot;open:Patterns/advection.vti&quot;&gt;advection equation&lt;/a&gt;.
+      &lt;a href=&quot;open:Patterns/advection.vti&quot;&gt;advection equation&lt;/a&gt;.
     </description>
     <rule name="Wave equation" type="formula" wrap="1" neighborhood_type="vertex">
       <param name="timestep">

--- a/Patterns/wave_soliton.vti
+++ b/Patterns/wave_soliton.vti
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<VTKFile type="ImageData" version="0.1" byte_order="LittleEndian" header_type="UInt32" compressor="vtkZLibDataCompressor">
+  <RD format_version="6">
+    <description>
+      The &lt;a href=&quot;https://en.wikipedia.org/wiki/Wave_equation&quot;&gt;wave equation&lt;/a&gt; says that the
+      second derivative (the rate of change of the rate of change) is proportional to the Laplacian of the value:
+
+      d^2a/dt^2 = laplacian_a
+
+      This pattern has been initialized with a soliton - a pulse that moves along without spreading out. Compare with the
+      &lt;a href&quot;open:Patterns/advection.vti&quot;&gt;advection equation&lt;/a&gt;.
+    </description>
+    <rule name="Wave equation" type="formula" wrap="1" neighborhood_type="vertex">
+      <param name="timestep">
+        0.600000
+      </param>
+      <formula number_of_chemicals="2">
+        b += laplacian_a * timestep;
+        delta_a = b;
+
+      </formula>
+    </rule>
+    <initial_pattern_generator apply_when_loading="false" zero_first="true">
+      <overlay chemical="a">
+        <overwrite/>
+        <gaussian height="4" sigma="0.05">
+          <point3D x="0.4" y="0.3" z="0.5"/>
+        </gaussian>
+        <everywhere/>
+      </overlay>
+    </initial_pattern_generator>
+    <render_settings>
+      <surface_color r="1" g="1" b="1"/>
+      <colormap value="spectral"/>
+      <color_low r="0" g="0" b="1"/>
+      <color_high r="1" g="0" b="0"/>
+      <show_color_scale value="true"/>
+      <show_multiple_chemicals value="true"/>
+      <active_chemical value="a"/>
+      <low value="-0.1"/>
+      <high value="1"/>
+      <vertical_scale_1D value="30"/>
+      <vertical_scale_2D value="50"/>
+      <contour_level value="0.25"/>
+      <cap_contour value="true"/>
+      <invert_contour_cap value="false"/>
+      <use_wireframe value="false"/>
+      <show_cell_edges value="false"/>
+      <show_bounding_box value="true"/>
+      <show_chemical_label value="true"/>
+      <slice_3D value="true"/>
+      <slice_3D_axis value="z"/>
+      <slice_3D_position value="0.5"/>
+      <show_displacement_mapped_surface value="true"/>
+      <color_displacement_mapped_surface value="false"/>
+      <use_image_interpolation value="true"/>
+      <timesteps_per_render value="1"/>
+      <show_phase_plot value="false"/>
+      <phase_plot_x_axis value="a"/>
+      <phase_plot_y_axis value="b"/>
+      <phase_plot_z_axis value="c"/>
+      <plot_ab_orthogonally value="false"/>
+    </render_settings>
+  </RD>
+  <ImageData WholeExtent="0 255 0 0 0 0" Origin="0 0 0" Spacing="1 1 1" Direction="1 0 0 0 1 0 0 0 1">
+  <Piece Extent="0 255 0 0 0 0">
+    <PointData>
+      <DataArray type="Float32" Name="a" format="binary" RangeMin="0" RangeMax="1.9971566200256348">
+        AQAAAACAAAAABAAAOgIAAA==eJxjYBgFAw2Ety0w3XyvxFTkkLLptjQpU87DAqYPHkmYzrPiMT3Hucz44aNYU8snRqaB7FNMC9rmmHLe+mv68q+f2YJz3WamU3ebRerymadO8zPf92+iuV31DfOEWhmLrypJFguvL7Com/vE4lG3oiWLdrKlYfU8S6uDty1XxopbGeT5W22T6bVaJbzfakUmgzXnTG3rtKvJ1gkh06y/ahy13lbJYCOapmaz2yDMhvF/h80vzXU2Tpx3bFKUuWznx+nYbj8Yatu8o9nWPnShrV3SEVufSW9tv53ns7u7WMuOeZGX3R3lfLsAux670KrFdguS99ot5LtlV9b6027WI177hDgF++mqJvb+8p72/Zrx9n6SZfaRd9vsZ7yYZO/GM9/+kdJqezuW7faebYfsv9eetQ8+cN1+lvJDe6uGl/bsmz7YS8z8Zn9D6rf9dqV/9lcW/bePm/Lffs/3v/arr/yyv2L5zb7O5oP9o+8v7H16Hti7yV23r796xn7P7YP2x6K32Yc0rLLnLp5nPyt6kv3buDZ7YdtSe/6COPu+Tg/7nM3G9hP5FOxVN/Pa30z8afdEHujmRXvtgu8vtjtxsMfOLLLAbvt3b7tsXh07ZScBu6iSD7Y3DI/birEtse1yaLPVLY6ytVhpYDuFic/22MdHNhyOW2wWBvTZbE+Kt8ny0LM5qctuM7P+gvXEl/OtrwmUWD+vsrRmmM1jHep71WrmuUVWFVNrrJbEeFnp+2hb0SvtAQCW7+MT
+      </DataArray>
+      <DataArray type="Float32" Name="b" format="binary" RangeMin="-0.09477747231721878" RangeMax="0.09449724853038788">
+        AQAAAACAAAAABAAAGAIAAA==eJxjYBgFgxlc02zbcufk6y0CW06afGhT2TrnkvzWAzG+W7cfDdm64cDLreuf6287W5S6LS923bY3y5i2H7ivv/3OycbtzT6btjfc/7fd7ZTBjtTLpTtmbVix45/Jsx0Zu2V2LjUO3rnfp3fn2WN7dipf+bHTfaPyrrNNobtm53btYrfbtCvs5uNdOQcEdn9YbLZb+VbK7pTcvt3ZXBt2C0ve2P1iJ/Oeh+Xyez7ssN8z/0bKHodF7Xvq587fU129a0+E3409Jdw/96j48+29mKW412CT6d6VH732vnqSsHeVVfnexcfb9gbsnLh3lcmcvbnflu5t2bZur5vutr0rhfbsfaR4YO9GqUN7m44e3Mv6dd/eyR07917L2bi3ZsGyvb1GM/d6O3fu3ceZt9eqyHWvWLLk3mWmV/ecWJq+x4aNefeslWo2dyu22jxW5rKdzmNuO3djgu0h02bbpmuTbQ+wLLJ1nbPW9mvHNtslJ/bY+mQesD3WftB2l+8B27Xv99iyr95u23pog+2emhW21YrzbU2/T7Gd5thlu6C+ztY+LMPWOCfI1lnC1nbdQg1bCUdR2zgFZtuIHU9sdnEes5FyWGWTHzLR5lhimU1Kur/NyRRdG8Of/DZalW+t7TsOWbt5z7Ne86Lemr3R19rvq7L15V+M1qYXzljNzV5g9eN7pdXTV45W9wTErJhKXlgOVPoCAJ8Z/MU=
+      </DataArray>
+    </PointData>
+    <CellData>
+    </CellData>
+  </Piece>
+  </ImageData>
+</VTKFile>

--- a/TODO.txt
+++ b/TODO.txt
@@ -15,7 +15,6 @@ Big picture issues:
 before 0.x release:
 
 - allow operations on chemicals: swap, duplicate
-- merged phase plot and graph for 1D patterns: plot graph at right angles, to e.g. show Schroedinger as a corkscrew
 - fix panning issue on complex scenes (e.g. Bays_3D.vti)
 - new fill types: perlin noise (vtkPerlinNoise), conical gradient
 - choice of log or linear color palette

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -415,9 +415,26 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     int iPhasePlotY = IndexFromChemicalName(render_settings.GetProperty("phase_plot_y_axis").GetChemical());
     int iPhasePlotZ = IndexFromChemicalName(render_settings.GetProperty("phase_plot_z_axis").GetChemical());
     bool plot_ab_orthogonally = render_settings.GetProperty("plot_ab_orthogonally").GetBool();
+    if (plot_ab_orthogonally && this->GetNumberOfChemicals() <= 1)
+    {
+        plot_ab_orthogonally = false;
+    }
 
-    int iFirstChem=0,iLastChem=this->GetNumberOfChemicals();
-    if(!show_multiple_chemicals) { iFirstChem = iActiveChemical; iLastChem = iFirstChem+1; }
+    int iFirstChem = 0;
+    int iLastChem = this->GetNumberOfChemicals() - 1;
+    if(!show_multiple_chemicals)
+    { 
+        if (plot_ab_orthogonally && iActiveChemical < 2)
+        {
+            iFirstChem = 0;
+            iLastChem = 1;
+        }
+        else
+        {
+            iFirstChem = iActiveChemical;
+            iLastChem = iFirstChem;
+        }
+    }
 
     float scaling = vertical_scale_1D / (high-low); // vertical_scale gives the height of the graph in worldspace units
     const float image_height = this->GetX() / this->image_ratio1D; // we thicken it 
@@ -426,7 +443,7 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
 
     vtkSmartPointer<vtkScalarsToColors> lut = GetColorMap(render_settings);
 
-    for(int iChem = iFirstChem; iChem < iLastChem; ++iChem)
+    for(int iChem = iFirstChem; iChem <= iLastChem; ++iChem)
     {
         // pass the image through the lookup table
         vtkSmartPointer<vtkImageMapToColors> image_mapper = vtkSmartPointer<vtkImageMapToColors>::New();
@@ -489,14 +506,14 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     // add a line graph for all the chemicals (active one highlighted)
     const float graph_bottom = this->image_top1D + y_gap;
     const float graph_top = graph_bottom + (high-low) * scaling;
-    for(int iChemical=iFirstChem;iChemical<iLastChem;iChemical++)
+    for(int iChemical = iFirstChem; iChemical <= iLastChem; iChemical++)
     {
         if (plot_ab_orthogonally && iChemical == 1)
         {
             continue;
         }
         vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-        if (plot_ab_orthogonally && iChemical == 0 && this->GetNumberOfChemicals() > 1)
+        if (plot_ab_orthogonally && iChemical == 0)
         {
             // plot the merged ab pair here
             vtkSmartPointer<vtkImageDataGeometryFilter> plane = vtkSmartPointer<vtkImageDataGeometryFilter>::New();
@@ -597,12 +614,13 @@ void ImageRD::InitializeVTKPipeline_2D(vtkRenderer* pRenderer,const Properties& 
     const float surface_bottom = offset[1] + 0.5 + this->GetY() + y_gap;
     const float surface_top = surface_bottom + this->GetY();
 
-    int iFirstChem=0,iLastChem=this->GetNumberOfChemicals();
-    if(!show_multiple_chemicals) { iFirstChem = iActiveChemical; iLastChem = iFirstChem+1; }
+    int iFirstChem = 0;
+    int iLastChem = this->GetNumberOfChemicals() - 1;
+    if(!show_multiple_chemicals) { iFirstChem = iActiveChemical; iLastChem = iFirstChem; }
 
     vtkSmartPointer<vtkScalarsToColors> lut = GetColorMap(render_settings);
 
-    for(int iChem=iFirstChem;iChem<iLastChem;iChem++)
+    for(int iChem = iFirstChem; iChem <= iLastChem; iChem++)
     {
         // pass the image through the lookup table
         vtkSmartPointer<vtkImageMapToColors> image_mapper = vtkSmartPointer<vtkImageMapToColors>::New();
@@ -795,14 +813,15 @@ void ImageRD::InitializeVTKPipeline_3D(vtkRenderer* pRenderer,const Properties& 
 
     vtkSmartPointer<vtkScalarsToColors> lut = GetColorMap(render_settings);
 
-    int iFirstChem=0,iLastChem=this->GetNumberOfChemicals();
-    if(!show_multiple_chemicals) { iFirstChem = iActiveChemical; iLastChem = iFirstChem+1; }
+    int iFirstChem = 0;
+    int iLastChem = this->GetNumberOfChemicals() - 1;
+    if(!show_multiple_chemicals) { iFirstChem = iActiveChemical; iLastChem = iFirstChem; }
 
     const float x_gap = this->x_spacing_proportion * this->GetX();
     const float y_gap = this->y_spacing_proportion * this->GetY();
     double offset[3] = {0,0,0};
 
-    for(int iChem = iFirstChem; iChem < iLastChem; ++iChem)
+    for(int iChem = iFirstChem; iChem <= iLastChem; ++iChem)
     {
         vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
 

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -572,6 +572,23 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     axis->SetNumberOfLabels(5);
     axis->PickableOff();
     pRenderer->AddActor(axis);
+    if (plot_ab_orthogonally)
+    {
+        vtkSmartPointer<vtkCubeAxesActor2D> axis = vtkSmartPointer<vtkCubeAxesActor2D>::New();
+        axis->SetCamera(pRenderer->GetActiveCamera());
+        axis->SetBounds(0, 0, graph_bottom, graph_bottom, low * scaling, high * scaling);
+        axis->SetRanges(0, 0, 0, 0, low, high);
+        axis->UseRangesOn();
+        axis->XAxisVisibilityOff();
+        axis->YAxisVisibilityOff();
+        axis->SetZLabel("");
+        axis->SetLabelFormat("%.2f");
+        axis->SetInertia(10000);
+        axis->SetCornerOffset(0);
+        axis->SetNumberOfLabels(5);
+        axis->PickableOff();
+        pRenderer->AddActor(axis);
+    }
 
     // add a phase plot
     const float phase_plot_bottom = graph_top + y_gap*2;

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -574,14 +574,15 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     pRenderer->AddActor(axis);
     if (plot_ab_orthogonally)
     {
+        axis->SetYLabel("a");
         vtkSmartPointer<vtkCubeAxesActor2D> axis = vtkSmartPointer<vtkCubeAxesActor2D>::New();
         axis->SetCamera(pRenderer->GetActiveCamera());
-        axis->SetBounds(0, 0, graph_bottom, graph_bottom, -low * scaling, -high * scaling);
+        axis->SetBounds(0, 0, graph_top, graph_top, -low * scaling, -high * scaling);
         axis->SetRanges(0, 0, 0, 0, low, high);
         axis->UseRangesOn();
         axis->XAxisVisibilityOff();
         axis->YAxisVisibilityOff();
-        axis->SetZLabel("");
+        axis->SetZLabel("b");
         axis->SetLabelFormat("%.2f");
         axis->SetInertia(10000);
         axis->SetCornerOffset(0);

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -576,7 +576,7 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     {
         vtkSmartPointer<vtkCubeAxesActor2D> axis = vtkSmartPointer<vtkCubeAxesActor2D>::New();
         axis->SetCamera(pRenderer->GetActiveCamera());
-        axis->SetBounds(0, 0, graph_bottom, graph_bottom, low * scaling, high * scaling);
+        axis->SetBounds(0, 0, graph_bottom, graph_bottom, -low * scaling, -high * scaling);
         axis->SetRanges(0, 0, 0, 0, low, high);
         axis->UseRangesOn();
         axis->XAxisVisibilityOff();

--- a/src/readybase/scene_items.cpp
+++ b/src/readybase/scene_items.cpp
@@ -183,4 +183,5 @@ void SetDefaultRenderSettings(Properties& render_settings)
     render_settings.AddProperty(Property("phase_plot_x_axis", "chemical", "a"));
     render_settings.AddProperty(Property("phase_plot_y_axis", "chemical", "b"));
     render_settings.AddProperty(Property("phase_plot_z_axis", "chemical", "c"));
+    render_settings.AddProperty(Property("plot_ab_orthogonally", false));
 }


### PR DESCRIPTION
Without this it is hard to grasp what the wave packet is doing in the Schrodinger equation (below).

Also added wave_soliton.vti and Lotka-Volterra_1D.vti, which can make use of the same feature.

![frame_000000](https://user-images.githubusercontent.com/647092/103703752-08724400-4fa0-11eb-9e80-f3b7f3f3fd2d.png)
![frame_000033](https://user-images.githubusercontent.com/647092/103703755-090ada80-4fa0-11eb-9ba7-196518cc9827.png)
![frame_000067](https://user-images.githubusercontent.com/647092/103703756-09a37100-4fa0-11eb-8f0e-db4fee6d757f.png)
