### PR TITLE
Support block size in formula image rules

### DIFF
--- a/Help/formats.html
+++ b/Help/formats.html
@@ -163,6 +163,9 @@ Attributes:
 <p>Attributes:
 <ul>
 <li><tt>number_of_chemicals</tt> (required) : The number of chemicals used.
+<li><tt>block_size_x</tt> (optional) : The x component of the dimensions of the spatial unit processed by each kernel call. Default: 4x1x1
+<li><tt>block_size_y</tt> (optional) : The y component.
+<li><tt>block_size_z</tt> (optional) : The z component.
 </ul>
 <p>Contains:
 <p>An OpenCL kernel snippet, where the chemicals are named a, b, c, etc.

--- a/src/gui/InfoPanel.cpp
+++ b/src/gui/InfoPanel.cpp
@@ -187,10 +187,9 @@ void InfoPanel::Update(const AbstractRD& system)
         contents += AppendRow(neighborhood_type_label, neighborhood_type_label, system.GetNeighborhoodType() + "-neighbors", false);
     }
 
-    /* bit technical, leave as a file-only option
     contents += AppendRow(block_size_label, block_size_label, wxString::Format(wxT("%d x %d x %d"),
                                         system.GetBlockSizeX(),system.GetBlockSizeY(),system.GetBlockSizeZ()),
-                                        system.HasEditableBlockSize());*/
+                                        system.HasEditableBlockSize());
 
     if (system.HasEditableWrapOption())
         contents += AppendRow(wrap_label, wrap_label, system.GetWrap() ? _("on") : _("off"), true);

--- a/src/gui/frame.cpp
+++ b/src/gui/frame.cpp
@@ -2400,9 +2400,7 @@ void MyFrame::SetBlockSize(int x,int y,int z)
     this->system->SetBlockSizeX(x);
     this->system->SetBlockSizeY(y);
     this->system->SetBlockSizeZ(z);
-    this->system->GenerateInitialPattern();
-    InitializeVTKPipeline(this->pVTKWindow, *this->system, this->render_settings, false);
-    this->UpdateWindows();
+    this->UpdateInfoPane();
 }
 
 // ---------------------------------------------------------------------

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -375,7 +375,7 @@ string FormulaOpenCLImageRD::AssembleKernelSourceFromFormula(const string& formu
     string amended_formula = formula;
     if (this->data_type == VTK_DOUBLE)
     {
-        // float4 doesn't auto-convert to double4
+        // float4 doesn't auto-convert to double4 or double
         amended_formula = ReplaceAllSubstrings(amended_formula, "float4", full_data_type_string);
     }
     else if (this->data_type == VTK_FLOAT)
@@ -406,6 +406,9 @@ void FormulaOpenCLImageRD::InitializeFromXML(vtkXMLDataElement *rd, bool &warn_t
     // formula:
     vtkSmartPointer<vtkXMLDataElement> xml_formula = rule->FindNestedElementWithName("formula");
     if(!xml_formula) throw runtime_error("formula node not found in file");
+    read_optional_attribute(xml_formula, "block_size_x", this->block_size[0]);
+    read_optional_attribute(xml_formula, "block_size_y", this->block_size[1]);
+    read_optional_attribute(xml_formula, "block_size_z", this->block_size[2]);
 
     // number_of_chemicals:
     read_required_attribute(xml_formula,"number_of_chemicals",this->n_chemicals);
@@ -428,6 +431,9 @@ vtkSmartPointer<vtkXMLDataElement> FormulaOpenCLImageRD::GetAsXML(bool generate_
     vtkSmartPointer<vtkXMLDataElement> formula = vtkSmartPointer<vtkXMLDataElement>::New();
     formula->SetName("formula");
     formula->SetIntAttribute("number_of_chemicals",this->GetNumberOfChemicals());
+    formula->SetIntAttribute("block_size_x", this->block_size[0]);
+    formula->SetIntAttribute("block_size_y", this->block_size[1]);
+    formula->SetIntAttribute("block_size_z", this->block_size[2]);
     string f = this->GetFormula();
     f = ReplaceAllSubstrings(f, "\n", "\n        "); // indent the lines
     formula->SetCharacterData(f.c_str(), (int)f.length());

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -34,7 +34,13 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
 
         std::string GetRuleType() const override { return "formula"; }
 
-        int GetBlockSizeX() const override { return 4; } // we use float4 in a 4x1x1 block
+        bool HasEditableBlockSize() const override { return true; }
+        int GetBlockSizeX() const override { return this->block_size[0]; }
+        int GetBlockSizeY() const override { return this->block_size[1]; }
+        int GetBlockSizeZ() const override { return this->block_size[2]; }
+        void SetBlockSizeX(int n) override { this->block_size[0] = n; this->need_reload_formula = true; }
+        void SetBlockSizeY(int n) override { this->block_size[1] = n; this->need_reload_formula = true; }
+        void SetBlockSizeZ(int n) override { this->block_size[2] = n; this->need_reload_formula = true; }
 
         std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
@@ -48,4 +54,8 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
         bool HasEditableWrapOption() const override { return true; }
         void SetWrap(bool w) override;
         bool HasEditableDataType() const override { return true; }
+
+    private:
+
+        int block_size[3];
 };

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -73,7 +73,7 @@ string InputPoint::GetName() const
 
 // ---------------------------------------------------------------------
 
-pair<InputPoint, InputPoint> InputPoint::GetAlignedBlocks() const
+pair<InputPoint, InputPoint> InputPoint::GetAlignedBlocks_Block411() const
 {
     if (point.x % 4 == 0)
     {
@@ -97,10 +97,10 @@ pair<InputPoint, InputPoint> InputPoint::GetAlignedBlocks() const
 
 // ---------------------------------------------------------------------
 
-string InputPoint::GetSwizzled() const
+string InputPoint::GetSwizzled_Block411() const
 {
     // assemble a non-block-aligned float4 for the requested point
-    const pair<InputPoint, InputPoint> blocks = GetAlignedBlocks();
+    const pair<InputPoint, InputPoint> blocks = GetAlignedBlocks_Block411();
     const InputPoint& block_left = blocks.first;
     const InputPoint& block_right = blocks.second;
     ostringstream oss;
@@ -124,9 +124,9 @@ string InputPoint::GetSwizzled() const
 
 // -------------------------------------------------------------------------
 
-string InputPoint::GetDirectAccessCode(bool wrap) const
+string InputPoint::GetDirectAccessCode(bool wrap, const int block_size[3]) const
 {
-    if (point.x % 4 != 0)
+    if (block_size[0] == 4 && point.x % 4 != 0)
     {
         throw runtime_error("internal error in GetDirectAccessCode: point.x not divisible by 4");
     }
@@ -137,7 +137,7 @@ string InputPoint::GetDirectAccessCode(bool wrap) const
         oss << "index_here";
     }
     else {
-        const string index_x = GetIndexString(point.x / 4, "x", "X", wrap);
+        const string index_x = GetIndexString(point.x / block_size[0], "x", "X", wrap);
         const string index_y = GetIndexString(point.y, "y", "Y", wrap);
         const string index_z = GetIndexString(point.z, "z", "Z", wrap);
         oss << "X* (Y * " << index_z << " + " << index_y << ") + " << index_x;
@@ -194,7 +194,7 @@ string Stencil::GetDivisorCode() const
 
 // ---------------------------------------------------------------------
 
-set<InputPoint> AppliedStencil::GetInputPoints_Block411() const
+set<InputPoint> AppliedStencil::GetInputPoints() const
 {
     set<InputPoint> input_points;
     for (const StencilPoint& stencil_point : stencil.points)

--- a/src/readybase/stencils.hpp
+++ b/src/readybase/stencils.hpp
@@ -69,9 +69,9 @@ struct InputPoint
     std::string chem;
 
     std::string GetName() const;
-    std::string GetDirectAccessCode(bool wrap) const;
-    std::string GetSwizzled() const;
-    std::pair<InputPoint, InputPoint> GetAlignedBlocks() const;
+    std::string GetDirectAccessCode(bool wrap, const int block_size[3]) const;
+    std::string GetSwizzled_Block411() const;
+    std::pair<InputPoint, InputPoint> GetAlignedBlocks_Block411() const;
     static std::string GetIndexString(int val, const std::string& coord, const std::string& coord_capital, bool wrap);
 
     friend bool operator<(const InputPoint& a, const InputPoint& b)
@@ -91,7 +91,7 @@ struct AppliedStencil
 
     std::string GetName() const { return stencil.label + "_" + chem; }
     std::string GetCode() const;
-    std::set<InputPoint> GetInputPoints_Block411() const;
+    std::set<InputPoint> GetInputPoints() const;
 };
 
 // ---------------------------------------------------------------------

--- a/src/readybase/utils.hpp
+++ b/src/readybase/utils.hpp
@@ -68,6 +68,14 @@ void read_required_attribute(vtkXMLDataElement* e,const std::string& name,T& val
         throw std::runtime_error(to_string(e->GetName())+" : failed to read required attribute: "+name);
 }
 
+template <typename T>
+void read_optional_attribute(vtkXMLDataElement* e,const std::string& name,T& val)
+{
+    const char *str = e->GetAttribute(name.c_str());
+    if(str && !from_string(str,val))
+        throw std::runtime_error(to_string(e->GetName())+" : failed to read optional attribute: "+name);
+}
+
 std::string GetChemicalName(size_t i); ///< a, b, c, ... z, aa, ab, ...
 int IndexFromChemicalName(const std::string& s);
 


### PR DESCRIPTION
This closes #124 

Supports 4x1x1 (float4 or double4) and 1x1x1 (float or double).

@danwills I hope this is useful for your Houdini efforts. Now you should be able to call `system->SetBlockSizeX(1)` and then `system->GetKernel()` will return: (e.g. for advection.vti)
```
__kernel void rd_compute(__global float *a_in,__global float *a_out)
{
    // parameters:
    const float dx = 0.10000000f;
    const float timestep = 0.00010000f;

    // keywords needed for the formula:
    const int index_x = get_global_id(0);
    const int index_y = get_global_id(1);
    const int index_z = get_global_id(2);
    const int X = get_global_size(0);
    const int Y = get_global_size(1);
    const int Z = get_global_size(2);
    const int index_here = X*(Y*index_z + index_y) + index_x;
    const float a_w = a_in[X* (Y * index_z + index_y) + ((index_x-1 + X) & (X - 1))];
    float a = a_in[index_here];
    const float a_e = a_in[X* (Y * index_z + index_y) + ((index_x+1 + X) & (X - 1))];
    const float x_gradient_a = (-1 * a_w + a_e) / (2 * dx);
    float delta_a = 0.0f;

    // the formula:
    delta_a = -x_gradient_a;

    // forward-Euler update step:
    a_out[index_here] = a + timestep * delta_a;
}
```

Let me know how else to make the interop with Houdini easier. Would it be useful to have a `system->GetFormulaKeywords()` that returned this part:
```
    const float x_gradient_a = (-1 * a_w + a_e) / (2 * dx);
```
Or something like that?