### PR TITLE
Added AbstractRD::GetData() to return the float values for a chemical

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -404,25 +404,23 @@ int main(int argc,char *argv[])
                 {
                     cout << "\n";
                     cout << "nchem: " << ix << "\n";
-                    const OpenCLImageRD &isystem = dynamic_cast<const OpenCLImageRD&>(*system);
 
                     cout << "xres=" << system->GetX() << "\n";
                     cout << "yres=" << system->GetY() << "\n";
                     cout << "zres=" << system->GetZ() << "\n";
 
                     // not in bytes!
-                    unsigned long reagent_block_size = system->GetX() * system->GetY() * system->GetZ();
+                    unsigned long reagent_size = system->GetX() * system->GetY() * system->GetZ();
 
-                    cout << "Reagent block size is: " << reagent_block_size << "\n";
-                    vector<float> rd_data(reagent_block_size);
+                    cout << "Reagent size is: " << reagent_size << "\n";
 
-                    isystem.GetFromOpenCLBuffers( &rd_data[0], ix );
+                    const vector<float> rd_data = system->GetData( ix );
 
                     cout << "\nRD data for reagent " << ix << ": [ ";
-                    for (unsigned long rix=0; rix<reagent_block_size; rix++)
+                    for (unsigned long rix=0; rix<rd_data.size(); rix++)
                     {
                         cout << rd_data[rix];
-                        if ( rix < reagent_block_size-1 )
+                        if ( rix < rd_data.size()-1 )
                         {
                             cout << ",";
                         }

--- a/src/readybase/AbstractRD.hpp
+++ b/src/readybase/AbstractRD.hpp
@@ -173,6 +173,8 @@ class AbstractRD
         /// Returns the total memory size that will need to be transferred to the GPU
         virtual size_t GetMemorySize() const =0;
 
+        virtual std::vector<float> GetData(int i_chemical) const =0;
+
         struct Parameter {
             std::string name;
             float value;

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -1697,3 +1697,22 @@ size_t ImageRD::GetMemorySize() const
 }
 
 // --------------------------------------------------------------------------------
+
+vector<float> ImageRD::GetData(int i_chemical) const
+{
+    vector<float> values(this->GetX() * this->GetY() * this->GetZ());
+    size_t i = 0;
+    for(int z = 0; z < this->GetZ(); z++)
+    {
+        for (int y = 0; y < this->GetY(); y++)
+        {
+            for (int x = 0; x < this->GetX(); x++)
+            {
+                values[i++] = this->images[i_chemical]->GetScalarComponentAsFloat(x, y, z, 0);
+            }
+        }
+    }
+    return values;
+}
+
+// --------------------------------------------------------------------------------

--- a/src/readybase/ImageRD.hpp
+++ b/src/readybase/ImageRD.hpp
@@ -82,6 +82,8 @@ class ImageRD : public AbstractRD
 
         size_t GetMemorySize() const override;
 
+        std::vector<float> GetData(int i_chemical) const override;
+
     protected:
 
         std::vector<vtkSmartPointer<vtkImageData>> images; ///< one for each chemical

--- a/src/readybase/MeshRD.cpp
+++ b/src/readybase/MeshRD.cpp
@@ -1052,3 +1052,16 @@ size_t MeshRD::GetMemorySize() const
 }
 
 // --------------------------------------------------------------------------------
+
+vector<float> MeshRD::GetData(int i_chemical) const
+{
+    vtkDataArray* data = this->mesh->GetCellData()->GetArray(GetChemicalName(i_chemical).c_str());
+    vector<float> values(this->mesh->GetNumberOfCells());
+    for (int i = 0; i < this->mesh->GetNumberOfCells(); i++)
+    {
+        values[i] = data->GetComponent(i, 0);
+    }
+    return values;
+}
+
+// --------------------------------------------------------------------------------

--- a/src/readybase/MeshRD.hpp
+++ b/src/readybase/MeshRD.hpp
@@ -75,6 +75,8 @@ class MeshRD : public AbstractRD
 
         size_t GetMemorySize() const override;
 
+        std::vector<float> GetData(int i_chemical) const override;
+
     protected: // functions
 
         void AddPhasePlot(  vtkRenderer* pRenderer,float scaling,float low,float high,float posX,float posY,float posZ,

--- a/src/readybase/OpenCLImageRD.cpp
+++ b/src/readybase/OpenCLImageRD.cpp
@@ -234,16 +234,6 @@ void OpenCLImageRD::ReadFromOpenCLBuffers()
 
 // ----------------------------------------------------------------------------------------------------------------
 
-void OpenCLImageRD::GetFromOpenCLBuffers(float* dest, int chemical_id) const
-{
-    // read from opencl buffers into our image
-    const unsigned long MEM_SIZE = sizeof(float) * this->GetX() * this->GetY() * this->GetZ();
-    cl_int ret = clEnqueueReadBuffer(this->command_queue,this->buffers[this->iCurrentBuffer][chemical_id], CL_TRUE, 0, MEM_SIZE, dest, 0, NULL, NULL);
-    throwOnError(ret,"OpenCLImageRD::GetFromOpenCLBuffers : buffer reading failed: ");
-}
-
-// ----------------------------------------------------------------------------------------------------------------
-
 void OpenCLImageRD::TestFormula(std::string program_string)
 {
     this->TestKernel(this->AssembleKernelSourceFromFormula(program_string));

--- a/src/readybase/OpenCLImageRD.hpp
+++ b/src/readybase/OpenCLImageRD.hpp
@@ -45,7 +45,6 @@ class OpenCLImageRD : public ImageRD, public OpenCL_MixIn
 
         void Undo() override;
         void Redo() override;
-        void GetFromOpenCLBuffers(float* dest, int chemical_id) const;
 
     protected:
 


### PR DESCRIPTION
This closes #97 

@danwills - I presume there wasn't a need to interact with OpenCL in the way this previously worked?

I see that rdy outputs the float values to stdout. Is this for getting the data into Houdini? There must be a faster way than parsing a long string - can Houdini provide a float pointer for writing into, for example?