### PR TITLE
Option to change the stencil accuracy

### DIFF
--- a/Help/changes.html
+++ b/Help/changes.html
@@ -21,6 +21,8 @@ the range [0,1]. This allows a neater and more accurate way of implementing para
 <li>Formulas now support <b>a_e</b>, <b>a_nw</b> etc. in a more natural way. Instead of accessing the float4 block that is
 the neighbor of the current block, these keywords return a float4 that has the four values that are neighbors in the specified way. Now we can do e.g. <tt>a = a_ne;</tt> in a formula to have the whole pattern shift down and left by one pixel. This is a
 <b>breaking change</b>: formula rules that accessed cells using a_w, a_e, a_nw, a_se, etc. will no longer behave as they did before.
+<li>New pattern setting: <tt>accuracy</tt>. Controls the size of the stencil. Use "low" to run fast, and "high" to run
+accurately.
 <li>Parameter <b>dx</b> is now reserved for controlling the grid spacing of the Gaussian, Laplacian, bi-Laplacian and tri-Laplacian
 stencils. Formula rules no longer need to write e.g. laplacian_a / (delta_x * delta_x) and can just write laplacian_a since the value of dx is used in the stencil computation.
 <li>New <a href="formats.html#render_settings">render setting</a>: <b>colormap</b>, with 11 maps available: "HSV blend", "spectral", "spectral reversed", "inferno", "inferno reversed", "terrain", "terrain reversed", "orange-purple", "purple-orange", "brown-teal", "teal-brown". The old behavior (HSV interpolation between two colors) is still available - choose "HSV blend".

--- a/Help/formats.html
+++ b/Help/formats.html
@@ -166,6 +166,7 @@ Attributes:
 <li><tt>block_size_x</tt> (optional) : The x component of the dimensions of the spatial unit processed by each kernel call. Default: 4x1x1
 <li><tt>block_size_y</tt> (optional) : The y component.
 <li><tt>block_size_z</tt> (optional) : The z component.
+<li><tt>accuracy</tt> (optional) : The stencil accuracy to use. "low", "medium" or "high". Default: "medium".
 </ul>
 <p>Contains:
 <p>An OpenCL kernel snippet, where the chemicals are named a, b, c, etc.

--- a/Help/quickstart.html
+++ b/Help/quickstart.html
@@ -71,6 +71,8 @@ To improve the overall speed here are some things to check:
 <li>Select the fastest OpenCL device - use Action > Select OpenCL Device...
 <li>Avoid using the same graphics card for rendering, if possible. For example on my laptop I can tell Windows that Ready
 should use the integrated graphics chip for rendering (Graphics Settings), which leaves the NVidia card free to run OpenCL.
+<li>Change the accuracy to low in the Info Pane, if this does not introduce artifacts into the pattern. View the kernel
+to see the effect of this setting.
 <li>Set the data type to float if possible. Using double is typically slower.
 <li>Try using local memory, with the setting in the Info Pane. This is a recent feature, let us know if it makes a
 dramatic difference.

--- a/Patterns/advection.vti
+++ b/Patterns/advection.vti
@@ -12,7 +12,9 @@
       The rate of change is the negative x gradient. The result is that patterns move to the right without changing shape, as
       if carried by some bulk flow or &lt;i&gt;advection&lt;/i&gt;.
 
-      (After a while distortions and instabilities appear because we are using only simple numerical methods.)
+      After a while distortions and instabilities appear because we are using only simple numerical methods. To reduce
+      the distortions, set the accuracy to 'high' below to use a 5-point stencil. To delay the onset of numerical instability,
+      use a smaller timestep or change the data type to 'double'.
     </description>
 
     <rule name="advection" type="formula" neighborhood_type="vertex">

--- a/src/gui/InfoPanel.cpp
+++ b/src/gui/InfoPanel.cpp
@@ -58,6 +58,8 @@ const wxString InfoPanel::data_type_label = _("Data type");
 const wxString InfoPanel::neighborhood_type_label = _("Neighborhood");
 const wxString InfoPanel::neighborhood_range_label = _("Neighborhood range");
 const wxString InfoPanel::neighborhood_weight_label = _("Neighborhood weight");
+const wxString InfoPanel::accuracy_label = _("Accuracy");
+const wxString InfoPanel::accuracy_labels[3] = { _("Low"), _("Medium"), _("High") };
 
 // -----------------------------------------------------------------------------
 
@@ -185,6 +187,11 @@ void InfoPanel::Update(const AbstractRD& system)
     {
         // (hide the neighborhood for vti files, which don't use it)
         contents += AppendRow(neighborhood_type_label, neighborhood_type_label, system.GetNeighborhoodType() + "-neighbors", false);
+    }
+
+    if (system.HasEditableAccuracyOption())
+    {
+        contents += AppendRow(accuracy_label, accuracy_label, accuracy_labels[static_cast<int>(system.GetAccuracy())], true);
     }
 
     contents += AppendRow(block_size_label, block_size_label, wxString::Format(wxT("%d x %d x %d"),
@@ -599,6 +606,26 @@ void InfoPanel::ChangeDimensions()
 
 // -----------------------------------------------------------------------------
 
+void InfoPanel::ChangeAccuracy()
+{
+    const AbstractRD::Accuracy old_val = frame->GetCurrentRDSystem().GetAccuracy();
+
+    wxArrayString choices;
+    for (const wxString& label : accuracy_labels)
+    {
+        choices.Add(label);
+    }
+    wxSingleChoiceDialog dlg(this, _("Accuracy:"), _("Select accuracy:"),
+        choices);
+    dlg.SetSelection(static_cast<int>(old_val));
+    if (dlg.ShowModal() != wxID_OK) return;
+    const AbstractRD::Accuracy new_val = static_cast<AbstractRD::Accuracy>(dlg.GetSelection());
+    frame->GetCurrentRDSystem().SetAccuracy(new_val);
+    Update(frame->GetCurrentRDSystem());
+}
+
+// -----------------------------------------------------------------------------
+
 void InfoPanel::ChangeBlockSize()
 {
     const AbstractRD& sys = frame->GetCurrentRDSystem();
@@ -679,6 +706,9 @@ void InfoPanel::ChangeInfo(const wxString& label)
 
     } else if ( label == dimensions_label ) {
         ChangeDimensions();
+
+    } else if ( label == accuracy_label ) {
+        ChangeAccuracy();
 
     } else if ( label == block_size_label ) {
         ChangeBlockSize();

--- a/src/gui/InfoPanel.cpp
+++ b/src/gui/InfoPanel.cpp
@@ -59,7 +59,7 @@ const wxString InfoPanel::neighborhood_type_label = _("Neighborhood");
 const wxString InfoPanel::neighborhood_range_label = _("Neighborhood range");
 const wxString InfoPanel::neighborhood_weight_label = _("Neighborhood weight");
 const wxString InfoPanel::accuracy_label = _("Accuracy");
-const wxString InfoPanel::accuracy_labels[3] = { _("Low"), _("Medium"), _("High") };
+const wxString InfoPanel::accuracy_labels[3] = { _("low"), _("medium"), _("high") };
 
 // -----------------------------------------------------------------------------
 

--- a/src/gui/InfoPanel.hpp
+++ b/src/gui/InfoPanel.hpp
@@ -89,6 +89,8 @@ class InfoPanel : public wxPanel
         static const wxString neighborhood_type_label;
         static const wxString neighborhood_range_label;
         static const wxString neighborhood_weight_label;
+        static const wxString accuracy_label;
+        static const wxString accuracy_labels[3];
 
 private:
         
@@ -106,6 +108,7 @@ private:
         void ChangeFormula();
         void ChangeDimensions();
         void ChangeBlockSize();
+        void ChangeAccuracy();
         void ChangeWrapOption();
         void ChangeDataType();
         

--- a/src/readybase/AbstractRD.cpp
+++ b/src/readybase/AbstractRD.cpp
@@ -31,6 +31,7 @@ using namespace std;
 AbstractRD::AbstractRD(int data_type)
     : x_spacing_proportion(0.05)
     , y_spacing_proportion(0.1)
+    , accuracy(Accuracy::Medium)
 {
     this->timesteps_taken = 0;
     this->need_reload_formula = true;

--- a/src/readybase/AbstractRD.hpp
+++ b/src/readybase/AbstractRD.hpp
@@ -133,6 +133,11 @@ class AbstractRD
         bool GetWrap() const { return this->wrap; }
         virtual void SetWrap(bool w) { this->wrap = w; }
 
+        virtual bool HasEditableAccuracyOption() const { return false; }
+        enum class Accuracy { Low, Medium, High };
+        Accuracy GetAccuracy() const { return this->accuracy; }
+        virtual void SetAccuracy(Accuracy acc) { this->accuracy = acc; }
+
         /// Retrieve the current 3D object as a vtkPolyData.
         virtual void GetAsMesh(vtkPolyData *out,const Properties& render_settings) const =0;
 
@@ -225,6 +230,8 @@ class AbstractRD
 
         double x_spacing_proportion;    /// spatial separation for rendering multiple chemicals, as a proportion of X
         double y_spacing_proportion;    /// spatial separation for rendering multiple chemicals, as a proportion of Y
+
+        Accuracy accuracy;
 
     protected: // functions
 

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -414,6 +414,20 @@ void FormulaOpenCLImageRD::InitializeFromXML(vtkXMLDataElement *rd, bool &warn_t
     // number_of_chemicals:
     read_required_attribute(xml_formula,"number_of_chemicals",this->n_chemicals);
 
+    // accuracy
+    string accuracy_string;
+    read_optional_attribute(xml_formula, "accuracy", accuracy_string);
+    if (accuracy_string.size() > 0)
+    {
+        const char* accuracy_labels[3] = { "low", "medium", "high" };
+        auto it = find(accuracy_labels, accuracy_labels + 3, accuracy_string);
+        if (it == accuracy_labels + 3)
+        {
+            throw std::runtime_error("unknown accuracy attribute: " + accuracy_string);
+        }
+        this->SetAccuracy(static_cast<AbstractRD::Accuracy>(it - accuracy_labels));
+    }
+
     string formula = trim_multiline_string(xml_formula->GetCharacterData());
     //this->TestFormula(formula); // will throw on error
     this->SetFormula(formula); // (won't throw yet)
@@ -435,6 +449,8 @@ vtkSmartPointer<vtkXMLDataElement> FormulaOpenCLImageRD::GetAsXML(bool generate_
     formula->SetIntAttribute("block_size_x", this->block_size[0]);
     formula->SetIntAttribute("block_size_y", this->block_size[1]);
     formula->SetIntAttribute("block_size_z", this->block_size[2]);
+    const char* accuracy_labels[3] = { "low", "medium", "high" };
+    formula->SetAttribute("accuracy", accuracy_labels[static_cast<int>(this->accuracy)]);
     string f = this->GetFormula();
     f = ReplaceAllSubstrings(f, "\n", "\n        "); // indent the lines
     formula->SetCharacterData(f.c_str(), (int)f.length());

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -65,12 +65,13 @@ struct InputsNeeded {
 
 // -------------------------------------------------------------------------
 
-InputsNeeded DetectInputsNeeded(const string& formula, int num_chemicals, int dimensionality, const int block_size[3])
+InputsNeeded DetectInputsNeeded(const string& formula, int num_chemicals, int dimensionality, const int block_size[3],
+                                const AbstractRD::Accuracy& accuracy)
 {
     InputsNeeded inputs_needed;
 
     const vector<string> formula_tokens = tokenize_for_keywords(formula);
-    const vector<Stencil> known_stencils = GetKnownStencils(dimensionality);
+    const vector<Stencil> known_stencils = GetKnownStencils(dimensionality, accuracy);
     for (int i = 0; i < num_chemicals; i++)
     {
         const string chem = GetChemicalName(i);
@@ -367,7 +368,7 @@ string FormulaOpenCLImageRD::AssembleKernelSourceFromFormula(const string& formu
     }
 
     const InputsNeeded inputs_needed = DetectInputsNeeded(formula, this->GetNumberOfChemicals(),
-        this->GetArenaDimensionality(), this->block_size);
+        this->GetArenaDimensionality(), this->block_size, this->GetAccuracy());
 
     const string indent = "    ";
     const KernelOptions options(this->wrap, indent, this->data_type, full_data_type_string, this->data_type_suffix, this->block_size);

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -45,7 +45,6 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
         bool HasEditableAccuracyOption() const override { return true; }
         void SetAccuracy(Accuracy acc) override { this->accuracy = acc; this->need_reload_formula = true; }
 
-
         std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -42,6 +42,8 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
         void SetBlockSizeY(int n) override { this->block_size[1] = n; this->need_reload_formula = true; }
         void SetBlockSizeZ(int n) override { this->block_size[2] = n; this->need_reload_formula = true; }
 
+        bool HasEditableAccuracyOption() const override { return true; }
+
         std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 
         // we override the parameter access functions because changing the parameters requires rewriting the kernel

--- a/src/readybase/FormulaOpenCLImageRD.hpp
+++ b/src/readybase/FormulaOpenCLImageRD.hpp
@@ -43,6 +43,8 @@ class FormulaOpenCLImageRD : public OpenCLImageRD
         void SetBlockSizeZ(int n) override { this->block_size[2] = n; this->need_reload_formula = true; }
 
         bool HasEditableAccuracyOption() const override { return true; }
+        void SetAccuracy(Accuracy acc) override { this->accuracy = acc; this->need_reload_formula = true; }
+
 
         std::string AssembleKernelSourceFromFormula(const std::string& formula) const override;
 

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -360,7 +360,7 @@ Stencil StencilFrom2DArray(const string& label, int const (&arr)[M][N], int divi
             arr2[j][i] = arr[j][i];
         }
     }
-    return StencilFrom2DArray(label, arr2, divisor, dx_power, dim1, dim2);
+    return StencilFrom2DArray<M,N>(label, arr2, divisor, dx_power, dim1, dim2);
 }
 
 // ---------------------------------------------------------------------
@@ -407,7 +407,7 @@ Stencil StencilFrom3DArray(const string& label, int const (&arr)[L][M][N], int d
             }
         }
     }
-    return StencilFrom3DArray(label, arr2, divisor, dx_power, dim1, dim2, dim3);
+    return StencilFrom3DArray<L,M,N>(label, arr2, divisor, dx_power, dim1, dim2, dim3);
 }
 
 // ---------------------------------------------------------------------
@@ -493,15 +493,15 @@ Stencil GetLaplacianStencil(int dimensionality, const AbstractRD::Accuracy& accu
         switch (accuracy)
         {
             case AbstractRD::Accuracy::Low:
-                return StencilFrom2DArray("laplacian", RotationallySymmetric3x3(0, 1, -4), 1, 2, 0, 1); // anisotropic
+                return StencilFrom2DArray<3,3>("laplacian", RotationallySymmetric3x3(0, 1, -4), 1, 2, 0, 1); // anisotropic
             case AbstractRD::Accuracy::Medium: // 2nd order version
-                return StencilFrom2DArray("laplacian", RotationallySymmetric3x3(1, 4, -20), 6, 2, 0, 1); // Known under the name "Mehrstellen"
+                return StencilFrom2DArray<3,3>("laplacian", RotationallySymmetric3x3(1, 4, -20), 6, 2, 0, 1); // Known under the name "Mehrstellen"
             case AbstractRD::Accuracy::High: // 4th order version
-                return StencilFrom2DArray("laplacian", RotationallySymmetric5x5(0, -2, -1, 16, 52, -252), 60, 2, 0, 1); // 21-point stencil
+                return StencilFrom2DArray<5,5>("laplacian", RotationallySymmetric5x5(0, -2, -1, 16, 52, -252), 60, 2, 0, 1); // 21-point stencil
         }
     case 3:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
-        return StencilFrom3DArray("laplacian", RotationallySymmetric3x3x3(1, 3, 14, -128), 30, 2, 0, 1, 2); // 27-point stencil
+        return StencilFrom3DArray<3,3>("laplacian", RotationallySymmetric3x3x3(1, 3, 14, -128), 30, 2, 0, 1, 2); // 27-point stencil
     default:
         throw runtime_error("Internal error: unsupported dimensionality in GetLaplacianStencil");
     }
@@ -520,10 +520,10 @@ Stencil GetBiLaplacianStencil(int dimensionality)
         return StencilFrom1DArray("bilaplacian", {1,-4,6,-4,1}, 1, 4, 0);
     case 2:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
-        return StencilFrom2DArray("bilaplacian", RotationallySymmetric5x5(0, 1, 1, -2, -10, 36), 3, 4, 0, 1);
+        return StencilFrom2DArray<5,5>("bilaplacian", RotationallySymmetric5x5(0, 1, 1, -2, -10, 36), 3, 4, 0, 1);
     case 3:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
-        return StencilFrom3DArray("bilaplacian", RotationallySymmetric5x5x5(-1, 0, 0, 10, 0, -20, -36, 0, 0, 360), 36, 4, 0, 1, 2); // 52-point stencil
+        return StencilFrom3DArray<5,5,5>("bilaplacian", RotationallySymmetric5x5x5(-1, 0, 0, 10, 0, -20, -36, 0, 0, 360), 36, 4, 0, 1, 2); // 52-point stencil
     default:
         throw runtime_error("Internal error: unsupported dimensionality in GetBiLaplacianStencil");
     }

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -285,20 +285,6 @@ Stencil StencilFrom1DArray(const string& label, int const (&arr)[N], int divisor
 // ---------------------------------------------------------------------
 
 template<int M, int N>
-Stencil StencilFrom2DArray(const string& label, int const (&arr)[M][N], int divisor, int dx_power, int dim1, int dim2)
-{
-    array<array<int, N>, M> arr2;
-    for (int j = 0; j < M; j++)
-    {
-        for (int i = 0; i < N; i++)
-        {
-            arr2[j][i] = arr[j][i];
-        }
-    }
-    return StencilFrom2DArray(label, arr2, divisor, dx_power, dim1, dim2);
-}
-
-template<int M, int N>
 Stencil StencilFrom2DArray(const string& label, const array<array<int, N>, M>& arr, int divisor, int dx_power, int dim1, int dim2)
 {
     if (M % 2 != 1 || N % 2 != 1)
@@ -322,24 +308,21 @@ Stencil StencilFrom2DArray(const string& label, const array<array<int, N>, M>& a
     return stencil;
 }
 
-// ---------------------------------------------------------------------
-
-template<int L, int M, int N>
-Stencil StencilFrom3DArray(const string& label, int const (&arr)[L][M][N], int divisor, int dx_power, int dim1, int dim2, int dim3)
+template<int M, int N>
+Stencil StencilFrom2DArray(const string& label, int const (&arr)[M][N], int divisor, int dx_power, int dim1, int dim2)
 {
-    array<array<array<int, N>, M>, L> arr2;
-    for (int k = 0; k < L; k++)
+    array<array<int, N>, M> arr2;
+    for (int j = 0; j < M; j++)
     {
-        for (int j = 0; j < M; j++)
+        for (int i = 0; i < N; i++)
         {
-            for (int i = 0; i < N; i++)
-            {
-                arr2[k][j][i] = arr[k][j][i];
-            }
+            arr2[j][i] = arr[j][i];
         }
     }
-    return StencilFrom3DArray(label, arr2, divisor, dx_power, dim1, dim2, dim3);
+    return StencilFrom2DArray(label, arr2, divisor, dx_power, dim1, dim2);
 }
+
+// ---------------------------------------------------------------------
 
 template<int L, int M, int N>
 Stencil StencilFrom3DArray(const string& label, const array<array<array<int, N>, M>, L>& arr, int divisor, int dx_power, int dim1, int dim2, int dim3)
@@ -367,6 +350,23 @@ Stencil StencilFrom3DArray(const string& label, const array<array<array<int, N>,
         }
     }
     return stencil;
+}
+
+template<int L, int M, int N>
+Stencil StencilFrom3DArray(const string& label, int const (&arr)[L][M][N], int divisor, int dx_power, int dim1, int dim2, int dim3)
+{
+    array<array<array<int, N>, M>, L> arr2;
+    for (int k = 0; k < L; k++)
+    {
+        for (int j = 0; j < M; j++)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                arr2[k][j][i] = arr[k][j][i];
+            }
+        }
+    }
+    return StencilFrom3DArray(label, arr2, divisor, dx_power, dim1, dim2, dim3);
 }
 
 // ---------------------------------------------------------------------

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -15,7 +15,6 @@
     You should have received a copy of the GNU General Public License
     along with Ready. If not, see <http://www.gnu.org/licenses/>.         */
 
-// Local:
 #include "stencils.hpp"
 
 // Stdlib:
@@ -364,7 +363,7 @@ Stencil GetGaussianStencil(int dimensionality)
 
 // ---------------------------------------------------------------------
 
-Stencil GetLaplacianStencil(int dimensionality)
+Stencil GetLaplacianStencil(int dimensionality, const AbstractRD::Accuracy& accuracy)
 {
     switch (dimensionality)
     {
@@ -372,7 +371,14 @@ Stencil GetLaplacianStencil(int dimensionality)
         return StencilFrom1DArray("laplacian", {1,-2,1}, 1, 2, 0);
     case 2:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
-        return StencilFrom2DArray("laplacian", {{1,4,1}, {4,-20,4}, {1,4,1}}, 6, 2, 0, 1); // Known under the name "Mehrstellen"
+        switch (accuracy)
+        {
+            case AbstractRD::Accuracy::Low:
+                return StencilFrom2DArray("laplacian", { {0,1,0}, {1,-4,1}, {0,1,0} }, 1, 2, 0, 1); // anisotropic
+            case AbstractRD::Accuracy::Medium:
+            case AbstractRD::Accuracy::High:
+                return StencilFrom2DArray("laplacian", { {1,4,1}, {4,-20,4}, {1,4,1} }, 6, 2, 0, 1); // Known under the name "Mehrstellen"
+        }
     case 3:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
         int c1, c2, c3, c4, divisor;
@@ -456,7 +462,7 @@ Stencil GetTriLaplacianStencil(int dimensionality)
 
 // ---------------------------------------------------------------------
 
-vector<Stencil> GetKnownStencils(int dimensionality)
+vector<Stencil> GetKnownStencils(int dimensionality, const AbstractRD::Accuracy& accuracy)
 {
     Stencil XGradient = StencilFrom1DArray("x_gradient", { -1, 0, 1 }, 2, 1, 0); // name, stencil, divisor, dx_power, axes
     //Stencil XGradient = StencilFrom1DArray("x_gradient", { 1, -8, 0, 8, -1 }, 12, 1, 0); // 4th order version
@@ -494,7 +500,7 @@ vector<Stencil> GetKnownStencils(int dimensionality)
                                                       {-1, 0, 1},
                                                       {0, 1, 2} }, 1, 0, 0, 1);
     Stencil Gaussian = GetGaussianStencil(dimensionality);
-    Stencil Laplacian = GetLaplacianStencil(dimensionality);
+    Stencil Laplacian = GetLaplacianStencil(dimensionality, accuracy);
     Stencil BiLaplacian = GetBiLaplacianStencil(dimensionality);
     Stencil TriLaplacian = GetTriLaplacianStencil(dimensionality);
     return { XGradient, YGradient, ZGradient,

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -501,7 +501,7 @@ Stencil GetLaplacianStencil(int dimensionality, const AbstractRD::Accuracy& accu
         }
     case 3:
         // Patra, M. & Karttunen, M. (2006) "Stencils with isotropic discretization error for differential operators" Numerical Methods for Partial Differential Equations, 22.
-        return StencilFrom3DArray<3,3>("laplacian", RotationallySymmetric3x3x3(1, 3, 14, -128), 30, 2, 0, 1, 2); // 27-point stencil
+        return StencilFrom3DArray<3,3,3>("laplacian", RotationallySymmetric3x3x3(1, 3, 14, -128), 30, 2, 0, 1, 2); // 27-point stencil
     default:
         throw runtime_error("Internal error: unsupported dimensionality in GetLaplacianStencil");
     }

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -419,7 +419,7 @@ Stencil GetGaussianStencil(int dimensionality)
         return StencilFrom1DArray("gaussian", {1,4,6,4,1}, 16, 0, 0);
     case 2:
         // from https://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm
-        return StencilFrom2DArray("gaussian", RotationallySymmetric5x5(1,4,7,16,26,41), 273, 0, 0, 1);
+        return StencilFrom2DArray<5,5>("gaussian", RotationallySymmetric5x5(1,4,7,16,26,41), 273, 0, 0, 1);
     case 3:
         // see Scripts/Python/convolve.py
         return StencilFrom3DArray("gaussian", {{{1,4,6,4,1},{4,16,25,16,4},{7,27,44,27,7},{4,16,25,16,4},{1,4,6,4,1}},

--- a/src/readybase/stencils.hpp
+++ b/src/readybase/stencils.hpp
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with Ready. If not, see <http://www.gnu.org/licenses/>.         */
 
+// Local:
+#include "AbstractRD.hpp"
+
 // Stdlib:
 #include <set>
 #include <string>
@@ -96,6 +99,6 @@ struct AppliedStencil
 
 // ---------------------------------------------------------------------
 
-std::vector<Stencil> GetKnownStencils(int dimensionality);
+std::vector<Stencil> GetKnownStencils(int dimensionality, const AbstractRD::Accuracy& accuracy);
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
This closes #127.

Reducing the accuracy to low from medium gives around a 10% speed boost. But we default to medium because there are anisotropic effects of using the smaller stencil:

With a low-accuracy Laplacian (0,1,0; 1,-4,1; 0,1,0):
![image](https://user-images.githubusercontent.com/647092/105412474-b7638080-5c2c-11eb-9fe5-5932c1e40dad.png)
Notice the squared-off waves.
Compare with using a medium-accuracy (isotropic, 2nd-order errors) Laplacian (1,4,1; 4,-20,4; 1,4,1)/20 (as was used previously, and is our new default) where the waves show no directional preference.
![image](https://user-images.githubusercontent.com/647092/105412736-06a9b100-5c2d-11eb-9714-f459ec9e0c3e.png)

Higher-accuracy stencils (4th order errors) are useful in advection.vti and likely others. See previous discussion here: #118 
