### PR TITLE
Warnings when compiling with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ endif()
 # create base library used by all executables
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  add_compile_definitions(VTK_OVERRIDE=override)
+  add_compile_options(-Wno-inconsistent-missing-override)
 endif()
 add_library( readybase STATIC ${BASE_SOURCES} )
 target_link_libraries( readybase ${VTK_LIBRARIES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ endif()
 # create base library used by all executables
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  add_target_definitions(readybase PUBLIC VTK_OVERRIDE=override)
+  target_compile_definitions(readybase PUBLIC VTK_OVERRIDE=override)
 endif()
 add_library( readybase STATIC ${BASE_SOURCES} )
 target_link_libraries( readybase ${VTK_LIBRARIES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
 endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  add_compile_options(readybase PRIVATE -Wno-inconsistent-missing-override)
+  add_compile_options(-Wno-inconsistent-missing-override)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,7 @@ endif()
 # create base library used by all executables
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  target_compile_definitions(readybase PUBLIC VTK_OVERRIDE=override)
+  add_compile_definitions(VTK_OVERRIDE=override)
 endif()
 add_library( readybase STATIC ${BASE_SOURCES} )
 target_link_libraries( readybase ${VTK_LIBRARIES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,7 +528,7 @@ endif()
 if( APPLE )
   # support macOS 10.10 or later
   add_definitions( -mmacosx-version-min=10.10 )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-nullability-completeness-on-arrays")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 if( APPLE OR UNIX )
   # use same settings as in makefiles
@@ -537,7 +537,6 @@ endif()
 
 # create base library used by all executables
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
-  # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
   add_compile_options(-Wno-inconsistent-missing-override)
 endif()
 add_library( readybase STATIC ${BASE_SOURCES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
 endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  target_compile_options(readybase PRIVATE -Wno-inconsistent-missing-override)
+  add_compile_options(readybase PRIVATE -Wno-inconsistent-missing-override)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,11 @@ if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
     MODULES ${VTK_LIBRARIES}
   )
 endif()
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
+  # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
+  target_compile_options(readybase PRIVATE " -Wno-inconsistent-missing-override")
+endif()
+
 
 # create command-line utility
 add_executable( ${CMD_NAME} ${CMD_SOURCES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
 endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
   # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  target_compile_options(readybase PRIVATE " -Wno-inconsistent-missing-override")
+  target_compile_options(readybase PRIVATE -Wno-inconsistent-missing-override)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,10 @@ if( APPLE OR UNIX )
 endif()
 
 # create base library used by all executables
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
+  # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
+  add_target_definitions(readybase PUBLIC VTK_OVERRIDE=override)
+endif()
 add_library( readybase STATIC ${BASE_SOURCES} )
 target_link_libraries( readybase ${VTK_LIBRARIES} )
 if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
@@ -543,10 +547,6 @@ if( VTK_VERSION VERSION_GREATER_EQUAL "8.90.0" )
     TARGETS readybase
     MODULES ${VTK_LIBRARIES}
   )
-endif()
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND VTK_VERSION VERSION_LESS "8.90.0")
-  # VTK < 9 used VTK_OVERRIDE which doesn't work on Clang
-  add_compile_options(-Wno-inconsistent-missing-override)
 endif()
 
 

--- a/src/gui/InfoPanel.cpp
+++ b/src/gui/InfoPanel.cpp
@@ -124,7 +124,7 @@ void InfoPanel::ResetPosition()
 
 // -----------------------------------------------------------------------------
 
-void InfoPanel::Update(const AbstractRD& system)
+void InfoPanel::UpdatePanel(const AbstractRD& system)
 {
     // build HTML string to display current parameters
     wxString contents;
@@ -624,7 +624,7 @@ void InfoPanel::ChangeAccuracy()
     if (dlg.ShowModal() != wxID_OK) return;
     const AbstractRD::Accuracy new_val = static_cast<AbstractRD::Accuracy>(dlg.GetSelection());
     frame->GetCurrentRDSystem().SetAccuracy(new_val);
-    Update(frame->GetCurrentRDSystem());
+    UpdatePanel(frame->GetCurrentRDSystem());
 }
 
 // -----------------------------------------------------------------------------
@@ -670,7 +670,7 @@ void InfoPanel::ChangeUseLocalMemory()
 {
     AbstractRD& sys = frame->GetCurrentRDSystem();
     sys.SetUseLocalMemory(!sys.GetUseLocalMemory());
-    this->Update(sys);
+    this->UpdatePanel(sys);
 }
 
 // -----------------------------------------------------------------------------
@@ -679,7 +679,7 @@ void InfoPanel::ChangeWrapOption()
 {
     AbstractRD& sys = frame->GetCurrentRDSystem();
     sys.SetWrap(!sys.GetWrap());
-    this->Update(sys);
+    this->UpdatePanel(sys);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/gui/InfoPanel.hpp
+++ b/src/gui/InfoPanel.hpp
@@ -40,7 +40,7 @@ class InfoPanel : public wxPanel
         InfoPanel(MyFrame* parent, wxWindowID id);
 
         // update the displayed info to reflect the state of the RD system
-        void Update(const AbstractRD& system);
+        void UpdatePanel(const AbstractRD& system);
         
         // bring up a suitable dialog for changing the given setting
         void ChangeInfo(const wxString& label);

--- a/src/gui/MakeNewSystem.cpp
+++ b/src/gui/MakeNewSystem.cpp
@@ -654,7 +654,7 @@ unique_ptr<AbstractRD> MakeNewHyperbolicSpace(const bool is_opencl_available, co
 
     const int NUM_TESSELLATION_TYPES = 4;
     // choose the tessellation
-    int tessellationType, schlafli1, schlafli2, schlafli3;
+    int tessellationType, schlafli1=0, schlafli2=0, schlafli3=0;
     {
         wxString descriptions[NUM_TESSELLATION_TYPES] = { "{4,3,5} : order-5 cubic honeycomb", "{5,3,4} : order-4 dodecahedral honeycomb",
             "{5,3,5} : order-5 dodecahedral honeycomb",  "{3,5,3} : icosahedral honeycomb" };

--- a/src/gui/dialogs.cpp
+++ b/src/gui/dialogs.cpp
@@ -218,9 +218,12 @@ bool XYZFloatDialog::TransferDataFromWindow()
 {
     double x,y,z;
     bool ok = this->xbox->GetValue().ToDouble(&x) && this->ybox->GetValue().ToDouble(&y) && this->zbox->GetValue().ToDouble(&z);
-    this->xval = x;
-    this->yval = y;
-    this->zval = z;
+    if (ok)
+    {
+        this->xval = x;
+        this->yval = y;
+        this->zval = z;
+    }
     return ok;
 }
 

--- a/src/gui/dialogs.hpp
+++ b/src/gui/dialogs.hpp
@@ -124,9 +124,9 @@ class ParameterDialog : public wxDialog
             void OnOneTimer(wxTimerEvent& event);
         #endif
     
-        virtual bool TransferDataFromWindow();  // called when user hits OK
+        bool TransferDataFromWindow() override;  // called when user hits OK
     
-        wxString GetName() { return name; }
+        wxString GetName() const override { return name; }
         float GetValue() { return value; }
     
     private:

--- a/src/gui/frame.cpp
+++ b/src/gui/frame.cpp
@@ -2114,7 +2114,8 @@ void MyFrame::ProcessKey(int key, int modifiers)
     switch (action.id)
     {
         case DO_NOTHING:        // any unassigned key (including escape) turns off full screen mode
-                                if (fullscreen) cmdid = ID::FullScreen; break;
+                                if (fullscreen) { cmdid = ID::FullScreen; }
+                                break;
 
         case DO_OPENFILE:       OpenFile(action.file);
                                 return;
@@ -2579,7 +2580,7 @@ bool MyFrame::LoadMesh(const wxFileName& mesh_filename, vtkUnstructuredGrid* ug)
             throw runtime_error("Unsupported file type");
         }
     }
-    catch (exception e)
+    catch (const exception& e)
     {
         wxMessageBox(_("Error importing mesh: ") + e.what(), _("Error"), wxOK | wxICON_ERROR);
         all_ok = false;

--- a/src/gui/frame.cpp
+++ b/src/gui/frame.cpp
@@ -251,18 +251,18 @@ const float MyFrame::brush_sizes[] = {0.002f, 0.005f, 0.01f, 0.02f, 0.05f};
 
 // constructor
 MyFrame::MyFrame(const wxString& title)
-       : wxFrame(NULL, wxID_ANY, title),
-       is_running(false),
-       speed_data_available(false),
-       i_timesteps_per_second_buffer(0),
-       time_at_last_render(0),
-       fullscreen(false),
-       render_settings("render_settings"),
-       is_recording(false),
-       CurrentCursor(TCursorType::POINTER),
-       current_paint_value(0.5f),
-       left_mouse_is_down(false),
-       right_mouse_is_down(false)
+   : wxFrame(NULL, wxID_ANY, title),
+    render_settings("render_settings"),
+    is_running(false),
+    time_at_last_render(0),
+    i_timesteps_per_second_buffer(0),
+    speed_data_available(false),
+    is_recording(false),
+    fullscreen(false),
+    CurrentCursor(TCursorType::POINTER),
+    current_paint_value(0.5f),
+    left_mouse_is_down(false),
+    right_mouse_is_down(false)
 {
     this->SetIcon(wxICON(appicon16));
     #ifdef __WXGTK__
@@ -596,7 +596,7 @@ void MyFrame::InitializeInfoPane()
 
 void MyFrame::UpdateInfoPane()
 {
-    this->info_panel->Update(*this->system);
+    this->info_panel->UpdatePanel(*this->system);
 }
 
 // ---------------------------------------------------------------------
@@ -1245,7 +1245,6 @@ void MyFrame::OnIdle(wxIdleEvent& event)
 
         if (steps_since_last_render >= timesteps_per_render) {
             // it's time to render what we've computed so far
-            int n_cells = this->system->GetNumberOfCells();
             if (this->computation_time_since_last_render == 0.0)
                 this->computation_time_since_last_render = 0.000001;  // unlikely, but play safe
             double time_since_last_render = time_before - this->time_at_last_render;
@@ -1386,7 +1385,6 @@ void MyFrame::OnSelectOpenCLDevice(wxCommandEvent& event)
     int iNewSelection = dlg.GetSelection();
     if(iNewSelection != iOldSelection)
         wxMessageBox(_("The selected device will be used the next time an OpenCL pattern is loaded."));
-    int dc = 0;
     for(int ip=0;ip<np;ip++)
     {
         int nd = OpenCL_utils::GetNumberOfDevices(ip);

--- a/src/gui/prefs.cpp
+++ b/src/gui/prefs.cpp
@@ -2140,7 +2140,7 @@ void PrefsDialog::OnButton(wxCommandEvent& event)
 
 void PrefsDialog::OnCheckBoxClicked(wxCommandEvent& event)
 {
-    int id = event.GetId();
+    //int id = event.GetId();
 
     // no need???
 }

--- a/src/gui/prefs.cpp
+++ b/src/gui/prefs.cpp
@@ -1003,8 +1003,9 @@ void linereader::setfile(FILE* f) {
 
 int linereader::close() {
      if (fp) {
-        return fclose(fp);
+        int ret = fclose(fp);
         fp = 0;
+        return ret;
     }
     return 0;
 }

--- a/src/readybase/AbstractRD.cpp
+++ b/src/readybase/AbstractRD.cpp
@@ -191,13 +191,9 @@ void AbstractRD::SetFilename(const string& s)
 
 void AbstractRD::InitializeFromXML(vtkXMLDataElement* rd, bool& warn_to_update)
 {
-    string str;
-    const char *s;
-    float f;
-    int i;
-
     // check whether we should warn the user that they need to update Ready
     {
+        int i;
         read_required_attribute(rd,"format_version",i);
         warn_to_update = (i > this->ready_format_version);
         // (we will still proceed and try to read the file but it might fail or give poor results)
@@ -207,11 +203,12 @@ void AbstractRD::InitializeFromXML(vtkXMLDataElement* rd, bool& warn_to_update)
     if(!rule) throw runtime_error("rule node not found in file");
 
     // rule_name:
+    string str;
     read_required_attribute(rule,"name",str);
     this->SetRuleName(str);
 
     // wrap-around
-    s = rule->GetAttribute("wrap");
+    const char *s = rule->GetAttribute("wrap");
     if(!s) this->wrap = true;
     else this->wrap = (string(s)=="1");
 
@@ -234,6 +231,7 @@ void AbstractRD::InitializeFromXML(vtkXMLDataElement* rd, bool& warn_to_update)
         if(!s) throw runtime_error("Failed to read param attribute: name");
         name = trim_multiline_string(s);
         s = node->GetCharacterData();
+        float f;
         if(!s || !from_string(s,f)) throw runtime_error("Failed to read param value");
         this->AddParameter(name,f);
     }
@@ -258,12 +256,12 @@ vtkSmartPointer<vtkXMLDataElement> AbstractRD::GetAsXML(bool generate_initial_pa
     // (Use this for when the format changes so much that the user will get better results if they update their Ready. File reading will still proceed but may fail.)
 
     // description
-    vtkSmartPointer<vtkXMLDataElement> description = vtkSmartPointer<vtkXMLDataElement>::New();
-    description->SetName("description");
+    vtkSmartPointer<vtkXMLDataElement> description_node = vtkSmartPointer<vtkXMLDataElement>::New();
+    description_node->SetName("description");
     string desc = this->GetDescription();
     desc = ReplaceAllSubstrings(desc, "\n", "\n      "); // indent the lines
-    description->SetCharacterData(desc.c_str(), (int)desc.length());
-    rd->AddNestedElement(description);
+    description_node->SetCharacterData(desc.c_str(), (int)desc.length());
+    rd->AddNestedElement(description_node);
 
     // rule
     vtkSmartPointer<vtkXMLDataElement> rule = vtkSmartPointer<vtkXMLDataElement>::New();

--- a/src/readybase/AbstractRD.cpp
+++ b/src/readybase/AbstractRD.cpp
@@ -29,15 +29,15 @@ using namespace std;
 // ---------------------------------------------------------------------
 
 AbstractRD::AbstractRD(int data_type)
-    : x_spacing_proportion(0.05)
-    , y_spacing_proportion(0.1)
-    , accuracy(Accuracy::Medium)
-    , use_local_memory(false)
+    : use_local_memory(false)
     , timesteps_taken(0)
     , need_reload_formula(true)
     , is_modified(false)
     , wrap(true)
     , neighborhood_type(TNeighborhood::VERTEX_NEIGHBORS)
+    , x_spacing_proportion(0.05)
+    , y_spacing_proportion(0.1)
+    , accuracy(Accuracy::Medium)
 {
     this->InternalSetDataType(data_type);
 

--- a/src/readybase/AbstractRD.hpp
+++ b/src/readybase/AbstractRD.hpp
@@ -62,7 +62,7 @@ class AbstractRD
         /// The formula is a piece of code (currently either an OpenCL snippet or a full OpenCL kernel) that drives the system.
         std::string GetFormula() const { return this->formula; }
         /// Throws std::runtime_error with information if the formula doesn't work.
-        virtual void TestFormula(std::string program_string) {}
+        virtual void TestFormula(std::string /*program_string*/) {}
         /// Changes the system's formula. The kernel will be reloaded on the next update step.
         void SetFormula(std::string s);
         /// Some implementations (e.g. inbuilt ones) cannot have their formula edited.
@@ -118,16 +118,16 @@ class AbstractRD
         virtual float GetX() const =0;
         virtual float GetY() const =0;
         virtual float GetZ() const =0;
-        virtual void SetDimensions(int x,int y,int z) {}
+        virtual void SetDimensions(int /*x*/,int /*y*/,int /*z*/) {}
 
         /// Only some implementations (e.g. FullKernelOpenCLImageRD) can have their block size edited.
         virtual bool HasEditableBlockSize() const { return false; }
         virtual int GetBlockSizeX() const { return 1; } ///< e.g. block size may be 4x1x1 for kernels that use float4 (like FormulaOpenCLImageRD)
         virtual int GetBlockSizeY() const { return 1; }
         virtual int GetBlockSizeZ() const { return 1; }
-        virtual void SetBlockSizeX(int n) {}
-        virtual void SetBlockSizeY(int n) {}
-        virtual void SetBlockSizeZ(int n) {}
+        virtual void SetBlockSizeX(int /*n*/) {}
+        virtual void SetBlockSizeY(int /*n*/) {}
+        virtual void SetBlockSizeZ(int /*n*/) {}
 
         bool GetUseLocalMemory() const { return this->use_local_memory; }
         void SetUseLocalMemory(bool val) { this->use_local_memory = val; this->need_reload_formula = true; }

--- a/src/readybase/FormulaOpenCLImageRD.cpp
+++ b/src/readybase/FormulaOpenCLImageRD.cpp
@@ -77,7 +77,7 @@ InputsNeeded DetectInputsNeeded(const string& formula, int num_chemicals, int di
         const string chem = GetChemicalName(i);
         inputs_needed.chemicals_needed.push_back(chem);
         // assume we will need the central cell
-        inputs_needed.cells_needed.insert({{ 0, 0, 0 }, chem });
+        inputs_needed.cells_needed.insert({ { { 0, 0, 0 } }, chem });
         // assume we need delta_<chem> for the forward Euler step
         inputs_needed.deltas_needed.push_back(chem);
         // assume we need local memory for every chemical
@@ -119,7 +119,7 @@ InputsNeeded DetectInputsNeeded(const string& formula, int num_chemicals, int di
             {
                 for (int z = -MAX_RADIUS; z <= MAX_RADIUS; z++)
                 {
-                    const InputPoint input_point{ {x, y, z}, chem };
+                    const InputPoint input_point{ { {x, y, z} }, chem };
                     if (UsingKeyword(formula_tokens, input_point.GetName()))
                     {
                         inputs_needed.cells_needed.insert(input_point);
@@ -481,7 +481,7 @@ void WriteKeywords(ostringstream& kernel_source, const InputsNeeded& inputs_need
         kernel_source << options.indent << "const " << options.data_type_string << " z_pos = index_z / (" << options.data_type_string << ")(Z);\n";
     }
     // write code for gradient_mag_squared if needed
-    for (const pair<string, int>& pair : inputs_needed.gradient_mag_squared)
+    for (const auto& pair : inputs_needed.gradient_mag_squared)
     {
         const string& chem = pair.first;
         const int dimensionality = pair.second;

--- a/src/readybase/ImageRD.cpp
+++ b/src/readybase/ImageRD.cpp
@@ -327,7 +327,6 @@ void ImageRD::GenerateInitialPattern()
                         continue; // best for now to silently ignore this overlay, because the user has no way of editing the overlays (short of editing the file)
                         //throw runtime_error("Overlay: chemical out of range: "+GetChemicalName(iC));
 
-                    double val = this->GetImage(iC)->GetScalarComponentAsDouble(x,y,z,0);
                     vector<double> vals(this->GetNumberOfChemicals());
                     for(int i=0;i<this->GetNumberOfChemicals();i++)
                         vals[i] = this->GetImage(i)->GetScalarComponentAsDouble(x,y,z,0);
@@ -404,14 +403,10 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
     float vertical_scale_1D = render_settings.GetProperty("vertical_scale_1D").GetFloat();
     bool use_image_interpolation = render_settings.GetProperty("use_image_interpolation").GetBool();
     int iActiveChemical = IndexFromChemicalName(render_settings.GetProperty("active_chemical").GetChemical());
-    float contour_level = render_settings.GetProperty("contour_level").GetFloat();
-    bool use_wireframe = render_settings.GetProperty("use_wireframe").GetBool();
     bool show_multiple_chemicals = render_settings.GetProperty("show_multiple_chemicals").GetBool();
     bool show_color_scale = render_settings.GetProperty("show_color_scale").GetBool();
     bool show_cell_edges = render_settings.GetProperty("show_cell_edges").GetBool();
-    bool show_bounding_box = render_settings.GetProperty("show_bounding_box").GetBool();
     bool show_chemical_label = render_settings.GetProperty("show_chemical_label").GetBool();
-    bool color_displacement_mapped_surface = render_settings.GetProperty("color_displacement_mapped_surface").GetBool();
     bool show_phase_plot = render_settings.GetProperty("show_phase_plot").GetBool();
     int iPhasePlotX = IndexFromChemicalName(render_settings.GetProperty("phase_plot_x_axis").GetChemical());
     int iPhasePlotY = IndexFromChemicalName(render_settings.GetProperty("phase_plot_y_axis").GetChemical());
@@ -440,7 +435,6 @@ void ImageRD::InitializeVTKPipeline_1D(vtkRenderer* pRenderer,const Properties& 
 
     float scaling = vertical_scale_1D / (high-low); // vertical_scale gives the height of the graph in worldspace units
     const float image_height = this->GetX() / this->image_ratio1D; // we thicken it 
-    const float x_gap = this->x_spacing_proportion * this->GetX();
     const float y_gap = image_height;
 
     vtkSmartPointer<vtkScalarsToColors> lut = GetColorMap(render_settings);
@@ -618,7 +612,6 @@ void ImageRD::InitializeVTKPipeline_2D(vtkRenderer* pRenderer,const Properties& 
     float vertical_scale_2D = render_settings.GetProperty("vertical_scale_2D").GetFloat();
     bool use_image_interpolation = render_settings.GetProperty("use_image_interpolation").GetBool();
     int iActiveChemical = IndexFromChemicalName(render_settings.GetProperty("active_chemical").GetChemical());
-    float contour_level = render_settings.GetProperty("contour_level").GetFloat();
     bool use_wireframe = render_settings.GetProperty("use_wireframe").GetBool();
     float surface_r,surface_g,surface_b;
     render_settings.GetProperty("surface_color").GetColor(surface_r,surface_g,surface_b);
@@ -1434,8 +1427,6 @@ void ImageRD::SaveFile(const char* filename,const Properties& render_settings,bo
 
 void ImageRD::GetAs2DImage(vtkImageData *out,const Properties& render_settings) const
 {
-    float low = render_settings.GetProperty("low").GetFloat();
-    float high = render_settings.GetProperty("high").GetFloat();
     int iActiveChemical = IndexFromChemicalName(render_settings.GetProperty("active_chemical").GetChemical());
 
     // create a lookup table for mapping values to colors

--- a/src/readybase/MeshRD.cpp
+++ b/src/readybase/MeshRD.cpp
@@ -169,12 +169,10 @@ void MeshRD::GenerateInitialPattern()
                 continue; // best for now to silently ignore this overlay, because the user has no way of editing the overlays (short of editing the file)
                 //throw runtime_error("Overlay: chemical out of range: "+GetChemicalName(iC));
 
-            double val;
             vector<double> vals(this->GetNumberOfChemicals());
             for(int i=0;i<this->GetNumberOfChemicals();i++)
             {
                 vals[i] = this->mesh->GetCellData()->GetArray(GetChemicalName(i).c_str())->GetComponent( iCell, 0 );
-                if(i==iC) val = vals[i];
             }
             this->mesh->GetCellData()->GetArray(GetChemicalName(iC).c_str())->SetComponent(iCell, 0, overlay.Apply(vals, *this, cp[0], cp[1], cp[2]));
         }

--- a/src/readybase/MeshRD.cpp
+++ b/src/readybase/MeshRD.cpp
@@ -876,8 +876,6 @@ void MeshRD::SetFrom2DImage(int iChemical, vtkImageData *im)
 float MeshRD::GetValue(float x, float y, float z, const Properties& render_settings)
 {
     const double X = this->GetX();
-    const double Y = this->GetY();
-    const double Z = this->GetZ();
 
     this->CreateCellLocatorIfNeeded();
 
@@ -915,8 +913,6 @@ float MeshRD::GetValue(float x, float y, float z, const Properties& render_setti
 void MeshRD::SetValue(float x,float y,float z,float val,const Properties& render_settings)
 {
     const double X = this->GetX();
-    const double Y = this->GetY();
-    const double Z = this->GetZ();
 
     this->CreateCellLocatorIfNeeded();
 

--- a/src/readybase/OpenCLImageRD.cpp
+++ b/src/readybase/OpenCLImageRD.cpp
@@ -210,7 +210,7 @@ void OpenCLImageRD::GenerateInitialPattern()
 
 void OpenCLImageRD::BlankImage(float value)
 {
-    ImageRD::BlankImage();
+    ImageRD::BlankImage(value);
     this->need_write_to_opencl_buffers = true;
 }
 

--- a/src/readybase/OpenCLMeshRD.cpp
+++ b/src/readybase/OpenCLMeshRD.cpp
@@ -316,7 +316,7 @@ void OpenCLMeshRD::GenerateInitialPattern()
 
 void OpenCLMeshRD::BlankImage(float value)
 {
-    MeshRD::BlankImage();
+    MeshRD::BlankImage(value);
     this->need_write_to_opencl_buffers = true;
 }
 

--- a/src/readybase/OpenCL_MixIn.cpp
+++ b/src/readybase/OpenCL_MixIn.cpp
@@ -29,19 +29,19 @@ using namespace std;
 // ---------------------------------------------------------------------------
 
 OpenCL_MixIn::OpenCL_MixIn(int opencl_platform, int opencl_device)
-    : global_range{ 1, 1, 1 }
+    : context(NULL)
+    , device_id(NULL)
+    , program(NULL)
+    , kernel(NULL)
+    , kernel_function_name("rd_compute")
+    , global_range{ 1, 1, 1 }
     , local_work_size{ 1, 1, 1 }
-    , iPlatform(opencl_platform)
-    , iDevice(opencl_device)
+    , command_queue(NULL)
     , need_reload_context(true)
     , need_write_to_opencl_buffers(true)
-    , kernel_function_name("rd_compute")
-    , device_id(NULL)
-    , context(NULL)
-    , command_queue(NULL)
-    , kernel(NULL)
-    , program(NULL)
     , iCurrentBuffer(0)
+    , iPlatform(opencl_platform)
+    , iDevice(opencl_device)
 {
     if(LinkOpenCL()!= CL_SUCCESS)
         throw runtime_error("Failed to load dynamic library for OpenCL");

--- a/src/readybase/overlays.cpp
+++ b/src/readybase/overlays.cpp
@@ -103,7 +103,7 @@ class Point3D : public XML_Object
 
         Point3D(vtkXMLDataElement *node);
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const;
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override;
 
         static const char* GetTypeName() { return "point3D"; }
 
@@ -140,14 +140,14 @@ class Add : public BaseOperation
 
         static const char* GetTypeName() { return "add"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Add::GetTypeName());
             return xml;
         }
 
-        virtual void Apply(double& target,double value) const { target += value; }
+        void Apply(double& target,double value) const override { target += value; }
 };
 
 class Subtract : public BaseOperation
@@ -158,14 +158,14 @@ class Subtract : public BaseOperation
 
         static const char* GetTypeName() { return "subtract"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Subtract::GetTypeName());
             return xml;
         }
 
-        virtual void Apply(double& target,double value) const { target -= value; }
+        void Apply(double& target,double value) const override { target -= value; }
 };
 
 class Overwrite : public BaseOperation
@@ -176,14 +176,14 @@ class Overwrite : public BaseOperation
 
         static const char* GetTypeName() { return "overwrite"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Overwrite::GetTypeName());
             return xml;
         }
 
-        virtual void Apply(double& target,double value) const { target = value; }
+        void Apply(double& target,double value) const override { target = value; }
 };
 
 class Multiply : public BaseOperation
@@ -194,14 +194,14 @@ class Multiply : public BaseOperation
 
         static const char* GetTypeName() { return "multiply"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Multiply::GetTypeName());
             return xml;
         }
 
-        virtual void Apply(double& target,double value) const { target *= value; }
+        void Apply(double& target,double value) const override { target *= value; }
 };
 
 class Divide : public BaseOperation
@@ -212,14 +212,14 @@ class Divide : public BaseOperation
 
         static const char* GetTypeName() { return "divide"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Divide::GetTypeName());
             return xml;
         }
 
-        virtual void Apply(double& target,double value) const { target /= value; }
+        void Apply(double& target,double value) const override { target /= value; }
 };
 
 // -------- fill methods: -----------
@@ -235,7 +235,7 @@ class Constant : public BaseFill
 
         static const char* GetTypeName() { return "constant"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Constant::GetTypeName());
@@ -243,7 +243,7 @@ class Constant : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             return this->value;
         }
@@ -266,7 +266,7 @@ class OtherChemical : public BaseFill
 
         static const char* GetTypeName() { return "other_chemical"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(OtherChemical::GetTypeName());
@@ -274,7 +274,7 @@ class OtherChemical : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system,const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system,const vector<double>& vals, float x, float y, float z) const override
         {
             if(this->iOtherChemical < 0 || this->iOtherChemical >= (int)vals.size())
                 throw runtime_error("OtherChemical:GetValue : chemical out of range");
@@ -297,7 +297,7 @@ class Parameter : public BaseFill
 
         static const char* GetTypeName() { return "parameter"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Parameter::GetTypeName());
@@ -305,7 +305,7 @@ class Parameter : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             return system.GetParameterValueByName(this->parameter_name.c_str());
         }
@@ -327,7 +327,7 @@ class WhiteNoise : public BaseFill
 
         static const char* GetTypeName() { return "white_noise"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(WhiteNoise::GetTypeName());
@@ -336,7 +336,7 @@ class WhiteNoise : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             return frand(this->low,this->high);
         }
@@ -362,7 +362,7 @@ class LinearGradient : public BaseFill
 
         static const char* GetTypeName() { return "linear_gradient"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(LinearGradient::GetTypeName());
@@ -373,7 +373,7 @@ class LinearGradient : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             double rel_x = x/system.GetX();
             double rel_y = y/system.GetY();
@@ -411,7 +411,7 @@ class RadialGradient : public BaseFill
 
         static const char* GetTypeName() { return "radial_gradient"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(RadialGradient::GetTypeName());
@@ -422,7 +422,7 @@ class RadialGradient : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             // convert p1 and p2 to absolute coordinates
             double rp1x = p1->x * system.GetX();
@@ -456,7 +456,7 @@ class Gaussian : public BaseFill
 
         static const char* GetTypeName() { return "gaussian"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Gaussian::GetTypeName());
@@ -466,7 +466,7 @@ class Gaussian : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             // convert center to absolute coordinates
             double ax = center->x * system.GetX();
@@ -499,7 +499,7 @@ class Sine : public BaseFill
 
         static const char* GetTypeName() { return "sine"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Sine::GetTypeName());
@@ -510,7 +510,7 @@ class Sine : public BaseFill
             return xml;
         }
 
-        virtual double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const
+        double GetValue(const AbstractRD& system, const vector<double>& vals, float x, float y, float z) const override
         {
             double rel_x = x/system.GetX();
             double rel_y = y/system.GetY();
@@ -542,14 +542,14 @@ class Everywhere : public BaseShape
 
         static const char* GetTypeName() { return "everywhere"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Everywhere::GetTypeName());
             return xml;
         }
 
-        virtual bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const
+        bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const override
         {
             return true;
         }
@@ -569,7 +569,7 @@ class Rectangle : public BaseShape
 
         static const char* GetTypeName() { return "rectangle"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Rectangle::GetTypeName());
@@ -578,7 +578,7 @@ class Rectangle : public BaseShape
             return xml;
         }
 
-        virtual bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const
+        bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const override
         {
             double rel_x = x/X;
             double rel_y = y/Y;
@@ -615,7 +615,7 @@ class Circle : public BaseShape
 
         static const char* GetTypeName() { return "circle"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Circle::GetTypeName());
@@ -624,7 +624,7 @@ class Circle : public BaseShape
             return xml;
         }
 
-        virtual bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const
+        bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const override
         {
             // convert the center and radius to absolute coordinates
             double cx = this->c->x * X;
@@ -659,7 +659,7 @@ class Pixel : public BaseShape
 
         static const char* GetTypeName() { return "pixel"; }
 
-        virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const
+        vtkSmartPointer<vtkXMLDataElement> GetAsXML() const override
         {
             vtkSmartPointer<vtkXMLDataElement> xml = vtkSmartPointer<vtkXMLDataElement>::New();
             xml->SetName(Pixel::GetTypeName());
@@ -669,7 +669,7 @@ class Pixel : public BaseShape
             return xml;
         }
 
-        virtual bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const
+        bool IsInside(float x,float y,float z,float X,float Y,float Z,int dimensionality) const override
         {
             switch(dimensionality)
             {

--- a/src/readybase/scene_items.cpp
+++ b/src/readybase/scene_items.cpp
@@ -49,7 +49,7 @@ void AddScalarBar(vtkRenderer* pRenderer,vtkScalarsToColors* lut)
     pRenderer->AddActor2D(scalar_bar);
 }
 
-template<size_t N>
+template<int N>
 void ColorMapFromList(vtkColorSeries* color_series, const float values[N][3])
 {
     color_series->SetNumberOfColors(N);

--- a/src/readybase/stencils.cpp
+++ b/src/readybase/stencils.cpp
@@ -262,7 +262,7 @@ string AppliedStencil::GetCode() const
         weights[stencil_point.weight].push_back(stencil_point.point);
     }
     bool is_first_weight_list = true;
-    for(const pair<int, vector<Point>>& weight_list : weights)
+    for(const auto& weight_list : weights)
     {
         if (!is_first_weight_list)
         {
@@ -315,7 +315,7 @@ Stencil StencilFrom1DArray(const string& label, int const (&arr)[N], int divisor
     {
         if (arr[i] != 0)
         {
-            Point point{ 0, 0, 0 };
+            Point point{ { 0, 0, 0 } };
             point.xyz[dim1] = i - (N - 1) / 2;
             stencil.points.push_back({ point, arr[i] });
         }
@@ -339,7 +339,7 @@ Stencil StencilFrom2DArray(const string& label, const array<array<int, N>, M>& a
         {
             if (arr[j][i] != 0)
             {
-                Point point{ 0, 0, 0 };
+                Point point{ { 0, 0, 0 } };
                 point.xyz[dim1] = i - (N - 1) / 2;
                 point.xyz[dim2] = - j + (M - 1) / 2; // rows are in reading order, heading south, which is negative y
                 stencil.points.push_back({ point, arr[j][i] });
@@ -381,7 +381,7 @@ Stencil StencilFrom3DArray(const string& label, const array<array<array<int, N>,
             {
                 if (arr[k][j][i] != 0)
                 {
-                    Point point{ 0, 0, 0 };
+                    Point point{ { 0, 0, 0 } };
                     point.xyz[dim1] = i - (N - 1) / 2;
                     point.xyz[dim2] = -j + (M - 1) / 2; // rows are in reading order, heading south, which is negative y
                     point.xyz[dim3] = k - (L - 1) / 2;
@@ -457,7 +457,7 @@ Stencil GetGaussianStencil(int dimensionality)
     {
     case 1:
         // from OpenCV
-        return StencilFrom1DArray("gaussian", {1,4,6,4,1}, 16, 0, 0);
+        return StencilFrom1DArray("gaussian", { 1,4,6,4,1 }, 16, 0, 0);
     case 2:
         // from https://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm
         return StencilFrom2DArray<5,5>("gaussian", RotationallySymmetric5x5(1,4,7,16,26,41), 273, 0, 0, 1);

--- a/src/readybase/utils.hpp
+++ b/src/readybase/utils.hpp
@@ -88,7 +88,7 @@ class XML_Object
 {
     public:
 
-        XML_Object(const vtkXMLDataElement* node) {}
+        XML_Object(const vtkXMLDataElement* /*node*/) {}
         virtual ~XML_Object() {}
         virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const =0;
 };

--- a/src/readybase/utils.hpp
+++ b/src/readybase/utils.hpp
@@ -89,6 +89,7 @@ class XML_Object
     public:
 
         XML_Object(const vtkXMLDataElement* node) {}
+        virtual ~XML_Object() {}
         virtual vtkSmartPointer<vtkXMLDataElement> GetAsXML() const =0;
 };
 


### PR DESCRIPTION
This fixes #132. The override issues have been fixed with later versions of VTK, and only clang picks them up, so a good fix is to suppress the warnings only for clang with older VTK. It's important to keep these override warnings for other cases.

Also fixed some genuine issues that Clang picks up, like missing overrides, unused variables, function hiding.

Removed `-Wno-nullability-completeness-on-arrays` on Apple builds. Not sure if we've fixed the underlying issues or if the config on our CI builds doesn't show it up but it looks like we no longer need that flag.