### PR TITLE
Checking existence of file before attempting to load

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -57,6 +57,8 @@ void printSeparator()
 
 int main(int argc,char *argv[])
 {
+    vtkObject::GlobalWarningDisplayOff();
+
     std::string blurb = "Ready commandline utility that uses readybase as a processing (and data-retrieval) back-end.\n"
                         "\n"
                         "It responds to various commandline arguments to load and print out parts of the system,\n"
@@ -146,8 +148,14 @@ int main(int argc,char *argv[])
         return EXIT_FAILURE;
     }
 
-    const bool is_opencl_available = OpenCL_utils::IsOpenCLAvailable();
+    const bool file_exists = static_cast<bool>(std::ifstream(vti_in));
+    if (!file_exists)
+    {
+        cout << "File does not exist: " << vti_in << endl;
+        return EXIT_FAILURE;
+    }
 
+    const bool is_opencl_available = OpenCL_utils::IsOpenCLAvailable();
     if( is_opencl_available )
     {
         if (verbose)


### PR DESCRIPTION
This closes #146. The exception was already being caught but the message wasn't very helpful, and VTK was displaying its internal error message.

This PR checks the input file's existence first, and prints a more helpful message. And it disables VTK's display of error messages in rdy (we do this in Ready already).

