### PR TITLE
Added two more dependency packages.

### DIFF
--- a/BUILD.txt
+++ b/BUILD.txt
@@ -97,7 +97,8 @@ C) Build Ready:
 A) Dependencies:
 
 On Debian/Ubuntu:
-sudo apt-get install libgtk-3-dev libxt-dev ocl-icd-opencl-dev libglu1-mesa-dev libvtk7-dev libwxgtk3.0-gtk3-dev cmake-curses-gui build-essential git
+sudo apt-get install libgtk-3-dev libxt-dev ocl-icd-opencl-dev libglu1-mesa-dev libvtk7-dev libwxgtk3.0-gtk3-dev cmake-curses-gui \
+build-essential libwxgtk3.0-gtk3-dev doxygen git
 
 On Fedora:
 sudo dnf install vtk-devel wxGTK3-devel ocl-icd-devel opencl-headers gcc-c++


### PR DESCRIPTION
Apparently cmake also wishes for Doxygen. A warning is shown when it is not present. The widgets are vital. Cmake aborts on an error when the wxWidgets package is not installed.